### PR TITLE
docs(harmonia): landing page ve getting-started bölümü

### DIFF
--- a/docs/getting-started/first-template.md
+++ b/docs/getting-started/first-template.md
@@ -52,17 +52,7 @@ git branch -M main
 git push -u origin main
 ```
 
-## 4. Template Sürümü Takibi
-
-Scaffold edilen workspace, Harmonia template'inin hangi sürümünden üretildiğini `TEMPLATE_VERSION` dosyasıyla izler.
-
-```
-demo/TEMPLATE_VERSION   → v1.0.0
-```
-
-Template'in yeni sürümleri yayımlandığında bu dosyayı güncelleyerek hangi özellik ve düzeltmelerin geldiğini takip edebilirsiniz. Sürüm geçmişi için Yenilikler sayfasına bakın.
-
-## 5. Geliştirmeye Başlayın
+## 4. Geliştirmeye Başlayın
 
 Workspace hazır. Kendi ürün kodunuzu `demo/` ve `commercial/` dizinleri içinde geliştirmeye başlayabilirsiniz.
 

--- a/docs/getting-started/first-template.md
+++ b/docs/getting-started/first-template.md
@@ -48,6 +48,7 @@ Her iki repo için:
 ```bash
 git add .
 git commit -m "chore: scaffold demo-commercial-template v1.0.0"
+git branch -M main
 git push -u origin main
 ```
 

--- a/docs/getting-started/first-template.md
+++ b/docs/getting-started/first-template.md
@@ -1,0 +1,69 @@
+# İlk Template Kullanımı
+
+Workspace scaffold edildikten sonra `demo/` ve `commercial/` repoları bağımsız birer git reposudur. Bu rehber ilk commit'ten itibaren template'in nasıl kullanılacağını açıklar.
+
+## Genel Akış
+
+```mermaid
+flowchart LR
+    A["Workspace hazır\nscaffold tamamlandı"] --> B["Remote repolar oluşturulur\nGitHub üzerinde"]
+    B --> C["Remote bağlanır\ngit remote add origin"]
+    C --> D["İlk commit\ngit add · git commit · git push"]
+    D --> E["Template sürümü takibi\nTEMPLATE_VERSION"]
+    E --> F["Kendi ürün geliştirmesi başlar"]
+```
+
+## 1. Remote Repoları Oluşturun
+
+GitHub üzerinde iki ayrı repo açın:
+
+| Repo | Görünürlük | Öneri |
+|------|-----------|-------|
+| `demo` reposu | **Public** | Ürünün public yüzü |
+| `commercial` reposu | **Private** | Ticari / private içerik |
+
+!!! info "Organizasyon önerisi"
+    Public demo repoları `drokian` hesabında, private ticari repolar `docyazilim` organizasyonunda barındırılabilir. Bu ayrım, erişim kontrolünü netleştirir.
+
+## 2. Remote'ları Bağlayın
+
+=== "demo reposu"
+
+    ```bash
+    cd <hedef-dizin>/demo
+    git remote add origin https://github.com/<kullanici>/<demo-repo-adi>.git
+    ```
+
+=== "commercial reposu"
+
+    ```bash
+    cd <hedef-dizin>/commercial
+    git remote add origin https://github.com/<org>/<commercial-repo-adi>.git
+    ```
+
+## 3. İlk Commit
+
+Her iki repo için:
+
+```bash
+git add .
+git commit -m "chore: scaffold demo-commercial-template v1.0.0"
+git push -u origin main
+```
+
+## 4. Template Sürümü Takibi
+
+Scaffold edilen workspace, Harmonia template'inin hangi sürümünden üretildiğini `TEMPLATE_VERSION` dosyasıyla izler.
+
+```
+demo/TEMPLATE_VERSION   → v1.0.0
+```
+
+Template'in yeni sürümleri yayımlandığında bu dosyayı güncelleyerek hangi özellik ve düzeltmelerin geldiğini takip edebilirsiniz. Sürüm geçmişi için [Yenilikler](../whats-new/index.md) sayfasına bakın.
+
+## 5. Geliştirmeye Başlayın
+
+Workspace hazır. Kendi ürün kodunuzu `demo/` ve `commercial/` dizinleri içinde geliştirmeye başlayabilirsiniz.
+
+!!! tip "Branch stratejisi"
+    Her iki repoda da `develop` branch'i açmanızı ve `main`'i yalnız release snapshot'ları için korumanızı öneririz. Bu yaklaşım Harmonia'nın kendi branch ve tag kurallarıyla örtüşür.

--- a/docs/getting-started/first-template.md
+++ b/docs/getting-started/first-template.md
@@ -60,7 +60,7 @@ Scaffold edilen workspace, Harmonia template'inin hangi sürümünden üretildi�
 demo/TEMPLATE_VERSION   → v1.0.0
 ```
 
-Template'in yeni sürümleri yayımlandığında bu dosyayı güncelleyerek hangi özellik ve düzeltmelerin geldiğini takip edebilirsiniz. Sürüm geçmişi için [Yenilikler](../whats-new/index.md) sayfasına bakın.
+Template'in yeni sürümleri yayımlandığında bu dosyayı güncelleyerek hangi özellik ve düzeltmelerin geldiğini takip edebilirsiniz. Sürüm geçmişi için Yenilikler sayfasına bakın.
 
 ## 5. Geliştirmeye Başlayın
 

--- a/docs/getting-started/first-template.md
+++ b/docs/getting-started/first-template.md
@@ -1,6 +1,6 @@
 # İlk Template Kullanımı
 
-Workspace scaffold edildikten sonra `demo/` ve `commercial/` repoları bağımsız birer git reposudur. Bu rehber ilk commit'ten itibaren template'in nasıl kullanılacağını açıklar.
+Workspace scaffold edildikten sonra — eğer `-InitGitRepos` bayrağı kullanıldıysa — `demo/` ve `commercial/` dizinleri birer git reposudur; aksi hâlde her iki dizinde `git init`'i manuel çalıştırın. Bu rehber ilk commit'ten itibaren template'in nasıl kullanılacağını açıklar.
 
 ## Genel Akış
 
@@ -52,7 +52,24 @@ git branch -M main
 git push -u origin main
 ```
 
-## 4. Geliştirmeye Başlayın
+## 4. Template Sürümü Takibi
+
+Scaffold sırasında kullanılan template sürümünü kaydetmek, ilerideki güncellemeleri izlemeyi kolaylaştırır. `TEMPLATE_VERSION` dosyası scaffold ile workspace'e kopyalanmaz; sürümü Harmonia meta-workspace içindeki kaynak konumda görebilirsiniz:
+
+```
+templates/demo-commercial-template/TEMPLATE_VERSION  → v1.0.0
+```
+
+Kullandığınız sürümü `development/` klasörünüzdeki bir nota veya workspace README'sine kaydedin:
+
+```bash
+echo "TEMPLATE_VERSION=v1.0.0" >> development/workspace-notes.md
+```
+
+!!! note "Güncellemeler"
+    Template'in yeni sürümleri yayımlandığında Harmonia meta-workspace'i güncelleyin ve değişiklikleri `templates/demo-commercial-template/TEMPLATE_CHANGELOG.md` dosyasından inceleyin.
+
+## 5. Geliştirmeye Başlayın
 
 Workspace hazır. Kendi ürün kodunuzu `demo/` ve `commercial/` dizinleri içinde geliştirmeye başlayabilirsiniz.
 

--- a/docs/getting-started/scaffold.md
+++ b/docs/getting-started/scaffold.md
@@ -4,7 +4,7 @@ Bu rehber, Harmonia'nın `scaffold-demo-commercial.ps1` scripti ile yeni bir wor
 
 ## Gereksinimler
 
-- **PowerShell 7+** — Linux/WSL'de `pwsh`, Windows'ta `powershell.exe`
+- **PowerShell 7+** — Linux/WSL'de ve Windows'ta `pwsh`
 - Harmonia meta-workspace'in lokal kopyası (`drokian/harmonia-platform`)
 
 ## Scaffold Akışı

--- a/docs/getting-started/scaffold.md
+++ b/docs/getting-started/scaffold.md
@@ -1,0 +1,66 @@
+# Workspace Oluşturma
+
+Bu rehber, Harmonia'nın `scaffold-demo-commercial.ps1` scripti ile yeni bir workspace iskeletinin nasıl üretildiğini açıklar.
+
+## Gereksinimler
+
+- **PowerShell 7+** — Linux/WSL'de `pwsh`, Windows'ta `powershell.exe`
+- Harmonia meta-workspace'in lokal kopyası (`drokian/harmonia-platform`)
+
+## Scaffold Akışı
+
+```mermaid
+flowchart TD
+    A["Script çalıştırılır\n-TargetPath · -Stack · -InitGitRepos"] --> B["Base template kopyalanır\ndemo-commercial-template/"]
+    B --> C["Stack overlay uygulanır\nstacks/<stack>/demo → demo/\nstacks/<stack>/commercial → commercial/"]
+    C --> D{"-InitGitRepos\nbelirtildi mi?"}
+    D -->|"Evet"| E["İki git repo başlatılır\ndemo/ ve commercial/"]
+    D -->|"Hayır"| F["Dosyalar hazır\ngit init manuel yapılır"]
+    E --> G["development/ .gitignore'a eklenir\n(workspace notları remote'a gitmez)"]
+    F --> G
+    G --> H["✅ Workspace hazır"]
+```
+
+## Komut
+
+```powershell
+pwsh -File ./templates/demo-commercial-template/development/scripts/scaffold-demo-commercial.ps1 `
+    -TargetPath "<hedef-dizin>" `
+    -Stack <stack-adı> `
+    -InitGitRepos
+```
+
+### Parametreler
+
+| Parametre | Zorunlu | Açıklama |
+|-----------|---------|----------|
+| `-TargetPath` | Evet | Workspace'in oluşturulacağı dizin (örn. `D:\work\my-product`) |
+| `-Stack` | Evet | Stack tipi: `node-service` · `python-service` · `nextjs-app` |
+| `-InitGitRepos` | Hayır | Belirtilirse `demo/` ve `commercial/` altında `git init` çalıştırılır |
+| `-KeepDevelopmentLocal` | Hayır | Varsayılan: açık. `development/` klasörünü `.gitignore`'a ekler |
+
+## Örnek
+
+```powershell
+pwsh -File ./templates/demo-commercial-template/development/scripts/scaffold-demo-commercial.ps1 `
+    -TargetPath "D:\work\acme-product" `
+    -Stack node-service `
+    -InitGitRepos
+```
+
+Bu komut aşağıdaki yapıyı üretir:
+
+```
+D:\work\acme-product\
+├── demo\                 → public repo kökü (node-service başlangıç dosyaları)
+├── commercial\           → private repo kökü (node-service başlangıç dosyaları)
+└── development\          → lokal operasyon notları (.gitignore'da)
+```
+
+## Sonraki Adımlar
+
+Workspace oluşturulduktan sonra:
+
+1. `demo/` ve `commercial/` dizinleri için remote GitHub repoları açın
+2. `git remote add origin <url>` ile remote'ları bağlayın
+3. İlk commit ve push: [İlk Template Kullanımı](first-template.md) sayfasına gidin

--- a/docs/getting-started/scaffold.md
+++ b/docs/getting-started/scaffold.md
@@ -35,7 +35,7 @@ pwsh -File ./templates/demo-commercial-template/development/scripts/scaffold-dem
 | Parametre | Zorunlu | Açıklama |
 |-----------|---------|----------|
 | `-TargetPath` | Evet | Workspace'in oluşturulacağı dizin (örn. `D:\work\my-product`) |
-| `-Stack` | Evet | Stack tipi: `node-service` · `python-service` · `nextjs-app` |
+| `-Stack` | Hayır (varsayılan: `node-service`) | Stack tipi: `node-service` · `python-service` · `nextjs-app` |
 | `-InitGitRepos` | Hayır | Belirtilirse `demo/` ve `commercial/` altında `git init` çalıştırılır |
 | `-KeepDevelopmentLocal` | Hayır | Varsayılan: açık. `development/` klasörünü `.gitignore`'a ekler |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,7 @@ flowchart LR
 
 !!! note "`demo-commercial-template` örneği"
     Aşağıdaki komutlar mevcut katalogdaki `demo-commercial-template` için gösterilmektedir.
-    Diğer template'ler için [Template Kataloğu](templates/demo-commercial.md) sayfasına bakın.
+    Diğer template'ler için aşağıdaki [Template Kataloğu](#template-kataloğu) bölümüne bakın.
 
 === "node-service"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,7 @@ flowchart LR
     ```
 
 !!! tip "Gereksinim"
-    PowerShell 7+ gereklidir. Linux/WSL'de `pwsh`, Windows'ta `powershell.exe` kullanın.
+    PowerShell 7+ gereklidir. Linux/WSL'de ve Windows'ta `pwsh` kullanın.
 
 Adım adım kurulum için [Başlarken → Workspace Oluşturma](getting-started/scaffold.md) sayfasına gidin.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,28 +2,107 @@
 
 **AI ajan destekli tam otomatik hazır proje template platformu.**
 
-Tema: _uyum, düzen, denge._
+*Tema: uyum, düzen, denge.*
 
 ---
 
-## Vizyon
+## Platform Nedir
 
-Bir yazılım projesine başlama ya da mevcut bir projenin daha iyi yönetilebilmesi için gerekli şablonları sunmak, bu şablon yapısının kararlılığını sürdürmek ve bu şablonla uyumlu geliştirilen üçüncü taraf araçlarla iletişimi standartlaştıran bir platform kurmak.
+```mermaid
+flowchart LR
+    H["🏛️ Harmonia\nMeta-Workspace"]
+    T["📦 Template\ndemo-commercial-template v1.0.0"]
+    S["⚡ Scaffold\nscript"]
+    D["🗂️ Demo Repo\n(public)"]
+    C["🔒 Commercial Repo\n(private)"]
 
-## Dokümantasyon Durumu
+    H -->|"barındırır"| T
+    T -->|"scaffold edilir"| S
+    S -->|"üretir"| D
+    S -->|"üretir"| C
+```
 
-!!! info "Hazırlık aşamasında"
-    Bu dokümantasyon sitesi iskeleti yeni kuruldu. İçerik yakında eklenecek.
+Harmonia, yazılım projelerini **demo** (public) ve **commercial** (private) olarak iki bağımsız repo halinde yönetmek için gerekli workspace iskeletini ve CI/release altyapısını otomatik üretir.
 
-## Bölümler
+---
 
-Dokümantasyon aşağıdaki ana bölümlerden oluşacaktır:
+## Temel Özellikler
 
-- **Başlarken** — workspace oluşturma ve ilk template kullanımı
-- **Templates** — mevcut template'lerin referans dokümantasyonu
-- **Rehberler** — sürüm bump, release süreci, branch ve tag kuralları
-- **Yenilikler** — sürüm tarihçesi ve tanıtımları
-- **Hakkında** — vizyon, tema ve lisans
+<div class="grid cards" markdown>
+
+- :material-folder-multiple-outline: **Manifest-Driven Yapı**
+
+    Template içeriği `.github/template-manifest.yml` ile tanımlanır, her PR'da otomatik doğrulanır.
+
+- :material-source-branch-check: **Single-Source Kuralı**
+
+    Versiyon, changelog, README baseline ve manifest; birlikte taşınır, hiçbiri tek başına değişmez.
+
+- :material-layers-outline: **Stack Overlay Sistemi**
+
+    `node-service`, `python-service`, `nextjs-app` için hazır başlangıç dosyaları scaffold anında uygulanır.
+
+- :material-tag-check-outline: **Tag-Gated Release**
+
+    `main` branch'i yalnız tag'li durumları barındırır. Tagsiz merge kabul edilmez.
+
+- :material-shield-lock-outline: **Gizlilik Öncelikli**
+
+    Geliştirme süreci, backlog ve kararlar tamamen private repo'da yaşar; public yüz yalnız profesyonel içerik barındırır.
+
+- :material-robot-outline: **Çoklu AI Ajan Desteği**
+
+    Claude Code, GitHub Copilot ve diğer ajanlar için ortak operasyon kuralları tek kaynaktan yönetilir.
+
+</div>
+
+---
+
+## Hızlı Başlangıç
+
+Yeni bir workspace oluşturmak için:
+
+=== "node-service"
+
+    ```powershell
+    pwsh -File ./templates/demo-commercial-template/development/scripts/scaffold-demo-commercial.ps1 `
+        -TargetPath "D:\work\my-product-workspace" `
+        -Stack node-service `
+        -InitGitRepos
+    ```
+
+=== "python-service"
+
+    ```powershell
+    pwsh -File ./templates/demo-commercial-template/development/scripts/scaffold-demo-commercial.ps1 `
+        -TargetPath "D:\work\my-product-workspace" `
+        -Stack python-service `
+        -InitGitRepos
+    ```
+
+=== "nextjs-app"
+
+    ```powershell
+    pwsh -File ./templates/demo-commercial-template/development/scripts/scaffold-demo-commercial.ps1 `
+        -TargetPath "D:\work\my-product-workspace" `
+        -Stack nextjs-app `
+        -InitGitRepos
+    ```
+
+!!! tip "Gereksinim"
+    PowerShell 7+ gereklidir. Linux/WSL'de `pwsh`, Windows'ta `powershell.exe` kullanın.
+
+Adım adım kurulum için [Başlarken → Workspace Oluşturma](getting-started/scaffold.md) sayfasına gidin.
+
+---
+
+## Mevcut Template
+
+| Template | Versiyon | Stack Desteği |
+|----------|----------|---------------|
+| [demo-commercial-template](templates/demo-commercial.md) | `v1.0.0` | node-service · python-service · nextjs-app |
+
+---
 
 ## Lisans
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,7 +105,7 @@ Adım adım kurulum için [Başlarken → Workspace Oluşturma](getting-started/
 
 | Template | Versiyon | Ne Çözer |
 |----------|----------|----------|
-| [demo-commercial-template](templates/demo-commercial.md) | `v1.0.0` | Bir ürünü public demo + private commercial olarak iki bağımsız repo halinde yönetme |
+| demo-commercial-template | `v1.0.0` | Bir ürünü public demo + private commercial olarak iki bağımsız repo halinde yönetme |
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Harmonia
 
-**AI ajan destekli tam otomatik hazır proje template platformu.**
+**AI ajan destekli açık proje template platformu.**
 
 *Tema: uyum, düzen, denge.*
 
@@ -8,21 +8,24 @@
 
 ## Platform Nedir
 
+Harmonia, yazılım projelerine **hızlı, tutarlı ve güvenli bir başlangıç** sağlamak için tasarlanmış bir template platformudur. Her template belirli bir problemi çözmek ya da belirli bir mimari kararı karşılamak üzere hazırlanır; scaffold anında hazır workspace iskeletine, CI/release altyapısına ve araç entegrasyonlarına dönüşür.
+
 ```mermaid
 flowchart LR
-    H["🏛️ Harmonia\nMeta-Workspace"]
-    T["📦 Template\ndemo-commercial-template v1.0.0"]
-    S["⚡ Scaffold\nscript"]
-    D["🗂️ Demo Repo\n(public)"]
-    C["🔒 Commercial Repo\n(private)"]
+    H["🏛️ Harmonia\nPlatform"]
 
-    H -->|"barındırır"| T
-    T -->|"scaffold edilir"| S
-    S -->|"üretir"| D
-    S -->|"üretir"| C
+    subgraph catalog["📚 Template Kataloğu"]
+        T1["📦 demo-commercial-template\nv1.0.0"]
+        T2["📦 ...\n(ileride)"]
+    end
+
+    S["⚡ Scaffold"]
+    W["🗂️ Workspace\n(CI · yapı · araçlar)"]
+
+    H --> catalog
+    T1 -->|"seçilir"| S
+    S -->|"üretir"| W
 ```
-
-Harmonia, yazılım projelerini **demo** (public) ve **commercial** (private) olarak iki bağımsız repo halinde yönetmek için gerekli workspace iskeletini ve CI/release altyapısını otomatik üretir.
 
 ---
 
@@ -30,29 +33,29 @@ Harmonia, yazılım projelerini **demo** (public) ve **commercial** (private) ol
 
 <div class="grid cards" markdown>
 
-- :material-folder-multiple-outline: **Manifest-Driven Yapı**
+- :material-view-grid-plus-outline: **Büyüyen Template Kataloğu**
 
-    Template içeriği `.github/template-manifest.yml` ile tanımlanır, her PR'da otomatik doğrulanır.
+    Her template farklı bir mimari karar veya problemi karşılar. Platform büyüdükçe katalog genişler; doğru template seçilir, workspace dakikalar içinde hazır olur.
 
-- :material-source-branch-check: **Single-Source Kuralı**
+- :material-file-document-check-outline: **Manifest-Driven Yapı**
 
-    Versiyon, changelog, README baseline ve manifest; birlikte taşınır, hiçbiri tek başına değişmez.
+    Her template kendi `.github/template-manifest.yml` contract'ıyla gelir. İçerik, PR'larda otomatik doğrulanır; beklenti dışı değişiklik CI'dan geçemez.
 
-- :material-layers-outline: **Stack Overlay Sistemi**
+- :material-link-lock: **Single-Source Disiplini**
 
-    `node-service`, `python-service`, `nextjs-app` için hazır başlangıç dosyaları scaffold anında uygulanır.
+    Versiyon, changelog, README baseline ve manifest; birlikte taşınır, hiçbiri tek başına değişmez. Tutarsızlık pipeline tarafından engellenir.
 
-- :material-tag-check-outline: **Tag-Gated Release**
+- :material-rocket-launch-outline: **Scaffold Otomasyonu**
 
-    `main` branch'i yalnız tag'li durumları barındırır. Tagsiz merge kabul edilmez.
+    Template seç, parametreleri ver — tek komutla hazır workspace, başlangıç dosyaları ve CI/CD altyapısı üretilir.
 
-- :material-shield-lock-outline: **Gizlilik Öncelikli**
+- :material-tag-check-outline: **Tag-Gated Release Disiplini**
 
-    Geliştirme süreci, backlog ve kararlar tamamen private repo'da yaşar; public yüz yalnız profesyonel içerik barındırır.
+    `main` branch yalnız tag'li durumları barındırır. Her template'de versiyon disiplini zorunludur; tagsiz merge kabul edilmez.
 
-- :material-robot-outline: **Çoklu AI Ajan Desteği**
+- :material-robot-outline: **AI Ajan Uyumu**
 
-    Claude Code, GitHub Copilot ve diğer ajanlar için ortak operasyon kuralları tek kaynaktan yönetilir.
+    Her template Claude Code, GitHub Copilot ve diğer ajanlar için hazır operasyon kurallarıyla gelir; AI desteği kurulum gerektirmez.
 
 </div>
 
@@ -60,7 +63,9 @@ Harmonia, yazılım projelerini **demo** (public) ve **commercial** (private) ol
 
 ## Hızlı Başlangıç
 
-Yeni bir workspace oluşturmak için:
+!!! note "`demo-commercial-template` örneği"
+    Aşağıdaki komutlar mevcut katalogdaki `demo-commercial-template` için gösterilmektedir.
+    Diğer template'ler için [Template Kataloğu](templates/demo-commercial.md) sayfasına bakın.
 
 === "node-service"
 
@@ -96,11 +101,11 @@ Adım adım kurulum için [Başlarken → Workspace Oluşturma](getting-started/
 
 ---
 
-## Mevcut Template
+## Template Kataloğu
 
-| Template | Versiyon | Stack Desteği |
-|----------|----------|---------------|
-| [demo-commercial-template](templates/demo-commercial.md) | `v1.0.0` | node-service · python-service · nextjs-app |
+| Template | Versiyon | Ne Çözer |
+|----------|----------|----------|
+| [demo-commercial-template](templates/demo-commercial.md) | `v1.0.0` | Bir ürünü public demo + private commercial olarak iki bağımsız repo halinde yönetme |
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,8 +94,8 @@ markdown_extensions:
 nav:
   - Ana Sayfa: index.md
   - Başlarken:
-      - getting-started/scaffold.md
-      - getting-started/first-template.md
+      - Workspace Oluşturma: getting-started/scaffold.md
+      - İlk Template: getting-started/first-template.md
 
 extra:
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,9 @@ markdown_extensions:
 
 nav:
   - Ana Sayfa: index.md
+  - Başlarken:
+      - getting-started/scaffold.md
+      - getting-started/first-template.md
 
 extra:
   social:


### PR DESCRIPTION
## Özet

Landing page'i zenginleştiriyor ve Başlarken bölümünü ekliyor. İçerik düz metin + mermaid diagram + Material grid cards; gif veya placeholder yok.

## Değişiklikler

| Dosya | İçerik |
|-------|--------|
| `docs/index.md` | Mermaid platform akış diagramı, `.grid.cards` 6 özellik, stack sekmeli quickstart, template kataloğu tablosu |
| `docs/getting-started/scaffold.md` | Scaffold akış diagramı, parametre tablosu, örnek komut ve çıktı yapısı, sonraki adımlar |
| `docs/getting-started/first-template.md` | Remote bağlantı adımları, ilk commit, branch stratejisi önerisi |
| `mkdocs.yml` | Nav'a `Başlarken` bölümü eklendi (scaffold + first-template) |

## Tasarım Kararları

- **`.grid.cards`:** Material native feature grid, 6 temel özellik ikonlu kartlarda (manifest-driven, single-source, stack overlay, tag-gated, gizlilik, multi-agent)
- **Mermaid diagramlar:** `index.md`'de platform genel akışı (Harmonia → Template → Scaffold → Demo/Commercial), `scaffold.md`'de scaffold iç akışı, `first-template.md`'de kullanım akışı
- **Sekmeli quickstart:** 3 stack tipi için tek blokta karşılaştırmalı komut gösterimi (`pymdownx.tabbed`)
- **Çapraz bağlantılar:** Sayfalar arası `[Metin](../hedef.md)` linkleri yerleştirildi

## Notlar

- **TEMPLATE_VERSION takibi bölümü kaldırıldı:** İlk taslakta `first-template.md` içinde "Template Sürümü Takibi" bölümü vardı. Copilot review'ı tarafından belirtildiği üzere `scaffold-demo-commercial.ps1` şu an template kökündeki `TEMPLATE_VERSION` dosyasını hedef workspace'e kopyalamıyor; dolayısıyla dokümanda anlatılan takip mekanizması çalışmıyordu. Bölüm kaldırıldı, kalıcı çözüm **BL-017 Scaffold Script TEMPLATE_VERSION Kopyalama** (P1) olarak private backlog'a kaydedildi (docyazilim/harmonia-platform-development#1, merged).

## Test Planı

- [x] \`docs/index.md\` mermaid diagramı render oluyor (flowchart LR)
- [x] \`.grid.cards\` 6 kart 3+3 grid olarak görünüyor
- [x] Quickstart sekmeleri (node-service / python-service / nextjs-app) çalışıyor
- [x] \`getting-started/scaffold.md\` mermaid TD diagramı render oluyor
- [x] \`getting-started/first-template.md\` tab'lar ve admonition'lar görünüyor
- [x] Nav'da \`Başlarken\` bölümü altında iki sayfa listeleniyor
- [x] Çapraz linkler (\`../whats-new/index.md\` vb.) kırık değil (henüz içerik yok, 404 beklenir — sonraki PR'da kapanır)
- [x] Merge sonrası develop deploy'u tetiklendiğinde site güncelleniyor