### PR TITLE
chore(harmonia): workspace scripts klasorunu koke tasi

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # Harmonia Scripts - Kullanim Dokumantasyonu
 
-Bu dokuman, `development/scripts` altindaki operasyon scriptlerinin amacini,
+Bu dokuman, `scripts` altindaki operasyon scriptlerinin amacini,
 parametrelerini ve ornek kullanimlarini tek yerde toplar.
 
 ## Icindekiler
@@ -36,7 +36,7 @@ Not: Windows ortaminda WSL/bash veya Git Bash kullanilmasi onerilir.
 
 Amac:
 - PR uzerindeki review comment, review event ve review thread verilerini toplar.
-- Ciktilari `development/ai-review/<repo>/PR<numara>/` altina yazar.
+- Ciktilari `ai-review/<repo>/PR<numara>/` altina yazar.
 
 Parametreler:
 
@@ -131,7 +131,7 @@ Ciktilar:
 ## 4) cleanup_v0.2.sh
 
 Amac:
-- Belirli bir repo + PR icin `development/ai-review/<repo>/PR<numara>` klasorunu temizler.
+- Belirli bir repo + PR icin `ai-review/<repo>/PR<numara>` klasorunu temizler.
 
 Parametreler:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,199 @@
+# Harmonia Scripts - Kullanim Dokumantasyonu
+
+Bu dokuman, `development/scripts` altindaki operasyon scriptlerinin amacini,
+parametrelerini ve ornek kullanimlarini tek yerde toplar.
+
+## Icindekiler
+
+- [Gereksinimler](#gereksinimler)
+- [Script Listesi](#script-listesi)
+- [1) review-collector_v0.2.sh](#1-review-collector_v02sh)
+- [2) reply-resolve_v0.2.sh](#2-reply-resolve_v02sh)
+- [3) verify-review-threads_v0.2.sh](#3-verify-review-threads_v02sh)
+- [4) cleanup_v0.2.sh](#4-cleanup_v02sh)
+- [5) create-repo_v0.3.sh](#5-create-repo_v03sh)
+- [Onerilen Operasyon Akisi](#onerilen-operasyon-akisi)
+- [Gelecek Gelistirme Notu](#gelecek-gelistirme-notu)
+- [Ayirma Zamani Hazirlik Notlari](#ayirma-zamani-hazirlik-notlari)
+
+## Gereksinimler
+
+- Bash 4+
+- GitHub CLI (`gh`) ve aktif oturum (`gh auth status`)
+- `jq`
+
+Not: Windows ortaminda WSL/bash veya Git Bash kullanilmasi onerilir.
+
+## Script Listesi
+
+- `review-collector_v0.2.sh`
+- `reply-resolve_v0.2.sh`
+- `verify-review-threads_v0.2.sh`
+- `cleanup_v0.2.sh`
+- `create-repo_v0.3.sh`
+
+## 1) review-collector_v0.2.sh
+
+Amac:
+- PR uzerindeki review comment, review event ve review thread verilerini toplar.
+- Ciktilari `development/ai-review/<repo>/PR<numara>/` altina yazar.
+
+Parametreler:
+
+| Parametre | Zorunlu | Aciklama |
+|---|---|---|
+| `owner` | Evet | GitHub owner (org/user) |
+| `repo` | Evet | Repository adi |
+| `pr_number` | Evet | PR numarasi (sayisal) |
+
+Kullanim:
+
+```bash
+bash scripts/review-collector_v0.2.sh <owner> <repo> <pr_number>
+```
+
+Urettigi temel dosyalar:
+- `copilot-comments.json`
+- `copilot-reviews.json`
+- `review-threads.json`
+- `copilot-review.md`
+
+## 2) reply-resolve_v0.2.sh
+
+Amac:
+- Copilot yorumlarina toplu/filtreli cevap verir.
+- Ilgili review thread'lerini resolve eder.
+
+Parametreler:
+
+| Parametre | Zorunlu | Aciklama |
+|---|---|---|
+| `owner` | Evet | GitHub owner (org/user) |
+| `repo` | Evet | Repository adi |
+| `pr_number` | Evet | PR numarasi (sayisal) |
+| `--mode` | Evet | `all`, `filter-text`, `filter-regex`, `map` |
+| `--reply-file` | Moda bagli | `all`/`filter-*` modlari icin reply metni dosyasi |
+| `--filter` | Moda bagli | `filter-text` modunda aranan metin |
+| `--regex` | Moda bagli | `filter-regex` modunda regex pattern |
+| `--map-file` | Moda bagli | `map` modunda pattern->reply JSON dosyasi |
+
+Kullanim (all mode):
+
+```bash
+bash scripts/reply-resolve_v0.2.sh <owner> <repo> <pr_number> \
+  --mode all \
+  --reply-file <reply.txt>
+```
+
+Kullanim (map mode):
+
+```bash
+bash scripts/reply-resolve_v0.2.sh <owner> <repo> <pr_number> \
+  --mode map \
+  --map-file <reply-map.json>
+```
+
+Notlar:
+- Map modunda bir comment birden fazla pattern ile eslesirse script fail-fast calisir.
+- Script, collector tarafindan uretilen JSON ciktilarini bekler.
+
+## 3) verify-review-threads_v0.2.sh
+
+Amac:
+- PR review thread durumlarini dogrular.
+- Acik thread kaldiysa non-zero exit code dondurur.
+
+Parametreler:
+
+| Parametre | Zorunlu | Aciklama |
+|---|---|---|
+| `owner` | Evet | GitHub owner (org/user) |
+| `repo` | Evet | Repository adi |
+| `pr_number` | Evet | PR numarasi (sayisal) |
+| `--show-resolved` | Hayir | Resolve edilmis thread listesini de yazar |
+
+Kullanim:
+
+```bash
+bash scripts/verify-review-threads_v0.2.sh <owner> <repo> <pr_number>
+```
+
+Opsiyonel:
+
+```bash
+bash scripts/verify-review-threads_v0.2.sh <owner> <repo> <pr_number> --show-resolved
+```
+
+Ciktilar:
+- `review-thread-verification.json`
+- `review-thread-verification.md`
+
+## 4) cleanup_v0.2.sh
+
+Amac:
+- Belirli bir repo + PR icin `development/ai-review/<repo>/PR<numara>` klasorunu temizler.
+
+Parametreler:
+
+| Parametre | Zorunlu | Aciklama |
+|---|---|---|
+| `repo` | Evet | Repository adi |
+| `pr_number` | Evet | PR numarasi (sayisal) |
+
+Kullanim:
+
+```bash
+bash scripts/cleanup_v0.2.sh <repo> <pr_number>
+```
+
+## 5) create-repo_v0.3.sh
+
+Amac:
+- Yerel calisma dizinini GitHub repo yapisina baglayan bootstrap adimlarini uygular.
+- Dry-run destekler.
+
+Parametreler:
+
+| Parametre | Zorunlu | Aciklama |
+|---|---|---|
+| `--dry-run` | Hayir | Yazma islemleri yerine planlanan adimlari loglar |
+| `hesap` | Evet | GitHub user/org adi |
+| `repo-adi` | Evet | Olusturulacak repo adi |
+| `public|private` | Evet | Repo gorunurlugu |
+
+Kullanim:
+
+```bash
+bash scripts/create-repo_v0.3.sh [--dry-run] <hesap> <repo-adi> <public|private>
+```
+
+## Onerilen Operasyon Akisi
+
+1. `review-collector_v0.2.sh` ile veriyi topla.
+2. Kod duzeltmelerini tamamla.
+3. `reply-resolve_v0.2.sh` ile yorumlara yanit ver ve thread resolve et.
+4. `verify-review-threads_v0.2.sh` ile thread durumunu dogrula.
+5. Gerekirse `cleanup_v0.2.sh` ile PR cikti klasorunu temizle.
+
+## Gelecek Gelistirme Notu
+
+Ileride bu scriptler icin daha moduler bir yapiya gecilecektir:
+- Her script icin ayri klasor yapisi
+- Her script icin ayri paketleme/surumleme modeli
+- Ortak kutuphane (logging, arg-parse, gh api wrapper, retry/backoff) ayrimi
+
+Bu gecis sonrasi bu dokuman, yeni klasor/paket yapisina gore guncellenecektir.
+
+## Ayirma Zamani Hazirlik Notlari
+
+Scriptleri ayirma/paketleme asamasinda isleri kolaylastirmak icin asagidaki sirayla ilerlenmesi onerilir:
+
+1. Ortak fonksiyonlari `lib/` altina tasiyin (log, arg parse, retry/backoff, gh wrappers).
+2. Her script icin ayri klasor olusturun (`scripts/<script-adi>/`).
+3. Her klasorde en az su dosyalari standardize edin:
+  - `README.md`
+  - `CHANGELOG.md`
+  - `run.sh`
+  - `tests/` (smoke test + happy path)
+4. Script bazli semver uygulayin (`v0.x`, `v1.x`) ve surumleri dosya adindan ayirip metadata dosyasina tasiyin.
+5. Gecis bitince bu merkezi README'yi sadece yonlendirme dokumani olarak sadeleştirin.

--- a/scripts/cleanup_v0.2.sh
+++ b/scripts/cleanup_v0.2.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# cleanup_v0.2.sh
+# ==============================================================================
+# HARMONIA CLEANUP ENGINE
+# ==============================================================================
+# Amaç:
+#   Bu script, belirli bir repository + PR için üretilen review artefact
+#   klasörünü güvenli şekilde temizlemek için kullanılır.
+#
+# Neden gerekli:
+#   Review akışı sonunda `ai-review/<repo>/PR<numara>` altında
+#   biriken dosyalar zamanla karmaşa yaratabilir. Bu script, hedef yolu
+#   doğrulayarak kontrollü temizlik sağlar.
+#
+# Özellikler:
+#   - Parametre doğrulama (`repo`, `pr_number`)
+#   - Güvenli path kontrolü (beklenen prefix doğrulaması)
+#   - Hedef dizin varsa silme, yoksa bilgilendirip atlama
+#   - Renkli ve okunabilir log çıktıları
+#
+# Değişiklik Geçmişi:
+# ------------------------------------------------------------------------------
+# v0.2  - [DOC] Script adı/üst bilgi standardı `HARMONIA ... ENGINE` formatına alındı
+#       - [DOC] Amaç/Neden/Özellikler bölümleri eklendi
+# v0.1  - İlk yayın
+# ==============================================================================
+
+set -euo pipefail
+
+RED="\033[31m"; GREEN="\033[32m"; CYAN="\033[36m"; RESET="\033[0m"
+
+log_info()  { echo -e "${CYAN}[INFO]${RESET}  $1"; }
+log_ok()    { echo -e "${GREEN}[OK]${RESET}    $1"; }
+log_error() { echo -e "${RED}[ERR]${RESET}   $1"; }
+
+if [[ $# -lt 2 ]]; then
+  log_error "Kullanım: $0 <repo> <pr_number>"
+  exit 1
+fi
+
+REPO="$1"
+PR_NUMBER="$2"
+
+if ! [[ "$REPO" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  log_error "repo adı dosya yolu için güvenli değil: $REPO"
+  exit 1
+fi
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  log_error "pr_number sayısal olmalı."
+  exit 1
+fi
+
+BASE_DIR="ai-review/${REPO}/PR${PR_NUMBER}"
+
+EXPECTED_PREFIX="ai-review/${REPO}/PR"
+if [[ "$BASE_DIR" != ${EXPECTED_PREFIX}* ]]; then
+  log_error "Geçersiz hedef dizin: $BASE_DIR"
+  exit 1
+fi
+
+if [[ -d "$BASE_DIR" ]]; then
+  rm -rf "$BASE_DIR"
+  log_ok "Temizlendi: $BASE_DIR"
+else
+  log_info "Dizin yok, atlanıyor: $BASE_DIR"
+fi
+

--- a/scripts/create-repo_v0.3.sh
+++ b/scripts/create-repo_v0.3.sh
@@ -1,0 +1,436 @@
+#!/usr/bin/env bash
+# create-repo.sh
+# ==============================================================================
+# HARMONIA REPO BOOTSTRAP ENGINE
+# ==============================================================================
+# Bu script, bir yerel çalışma dizinini GitHub'a bağlar ve standart proje
+# yapılandırmalarını tek komutla uygular.
+#
+# Uygulanan adımlar sırasıyla:
+# ------------------------------------------------------------------------------
+# • Git Başlatma
+#     - Çalışma dizininde git repo yoksa otomatik olarak başlatılır
+#     - Aktif branch "main" olarak adlandırılır
+#
+# • İlk Commit
+#     - Hassas dosya varlığı kontrol edilir (.env, *.key, *.pem vb.)
+#     - .gitignore'da tanımlı dosyalar tarama dışı bırakılır
+#     - Kullanıcıdan onay istenir; onay gelmezse işlem durur
+#     - git add . → chore: initial commit
+#
+# • GitHub Repo Oluşturma
+#     - gh repo create --push ile repo açılır ve main push edilir
+#
+# • Branch Yapısı
+#     - develop branch oluşturulur ve push edilir
+#     - develop default branch olarak ayarlanır
+#
+# • Branch Koruma
+#     - main ve develop için branch protection kuralları uygulanır
+#     - Force push ve deletion engellenir
+#
+# • Merge Yöntemi
+#     - Yalnızca squash merge aktif edilir
+#
+# • Copilot Auto Review
+#     - Repo düzeyinde Copilot Auto Review aktif edilir
+#
+# Dry-Run Modu (--dry-run / -n):
+# ------------------------------------------------------------------------------
+# • Tüm yazma işlemleri (git commit, git push, gh api, gh repo create) atlanır
+# • Atlanacak komutlar [DRY-RUN] etiketiyle ekrana ve log dosyasına yazılır
+# • Okuma ve doğrulama adımları (gh auth, git log, hassas dosya tarama) çalışır
+# • Gerçek işlem yapmadan log çıktısını incelemek için kullanılır
+#
+# Bağımlılıklar:
+# ------------------------------------------------------------------------------
+# • bash 4+
+# • gh (GitHub CLI) — oturum açık olmalı
+# • git
+#
+# Harmonia İlkeleri:
+# ------------------------------------------------------------------------------
+# Order     → Hassas dosya kontrolü ve kullanıcı onayı olmadan commit yapılmaz
+# Balance   → Okuma operasyonları dry-run'da da çalışır, yazma operasyonları atlanır
+# Structure → Bootstrap adımları deterministik sırayla uygulanır
+# Discipline→ Her kritik adım sonrası başarı/hata logu yazılır
+#
+# Değişiklik Geçmişi:
+# ------------------------------------------------------------------------------
+# v0.3  - [FIX] Copilot Auto Review endpoint'i 404 dönerse işlem artık fatal
+#           hata yerine uyarı olarak ele alınıyor; organizasyon veya repo planı
+#           bu özelliği desteklemese de bootstrap akışı tamamlanabiliyor
+# v0.2  - [FIX] guard_sensitive_paths: find yerine git ls-files kullanılıyor;
+#           .gitignore'da tanımlı dosyalar artık false positive üretmiyor
+#       - [FIX] gh repo create | tee pipe'ında pipefail bypass riski giderildi;
+#           gh çıktısı önce dosyaya yönlendiriliyor, PIPESTATUS kontrol ediliyor
+#       - [FIX] HAS_GIT_REPO flag mantığı basitleştirildi; git init sonrası
+#           ensure_main_branch koşulsuz olarak dry() sarmalayıcısına devrediliyor
+#       - [FIX] develop checkout sonrası main'e geri dönülüyor; branch
+#           bağlamı deterministik hale getirildi
+# v0.1  - İlk yayın
+# ==============================================================================
+
+set -euo pipefail
+
+# Renkler
+RED="\033[31m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+BLUE="\033[34m"
+MAGENTA="\033[35m"
+CYAN="\033[36m"
+BOLD="\033[1m"
+RESET="\033[0m"
+
+show_help() {
+    echo -e "${BOLD}${CYAN}Kullanım:${RESET}"
+    echo -e "  ${YELLOW}./create-repo.sh [--dry-run] <hesap> <repo-adi> <public|private>${RESET}"
+    echo
+
+    echo -e "${BOLD}${CYAN}Açıklama:${RESET}"
+    echo -e "  Workspace klasörünü GitHub'a bağlar ve standart yapılandırmaları uygular."
+    echo -e "  Git reposu yoksa otomatik olarak başlatılır ve ilk commit atılır."
+    echo -e "  ${GREEN}main${RESET} ve ${GREEN}develop${RESET} branch'leri olusturulur,"
+    echo -e "  ${GREEN}develop${RESET} default yapilir,"
+    echo -e "  branch koruma kuralları uygulanır,"
+    echo -e "  merge yöntemi ${MAGENTA}squash-only${RESET} yapılır,"
+    echo -e "  Copilot Auto Review aktif edilir."
+    echo
+
+    echo -e "${BOLD}${CYAN}Seçenekler:${RESET}"
+    echo -e "  ${YELLOW}--dry-run, -n${RESET}  Gerçek işlem yapmadan tüm adımları loglar"
+    echo
+
+    echo -e "${BOLD}${CYAN}Parametreler:${RESET}"
+    echo -e "  ${YELLOW}hesap${RESET}          GitHub hesabi veya organizasyon (orn: ${GREEN}drokian${RESET}, ${GREEN}docyazilim${RESET})"
+    echo -e "  ${YELLOW}repo-adi${RESET}       Olusturulacak repo adi (orn: ${GREEN}doc-notes${RESET})"
+    echo -e "  ${YELLOW}public|private${RESET} Repo görünürlüğü"
+    echo
+
+    echo -e "${BOLD}${CYAN}Ornek:${RESET}"
+    echo -e "  ${GREEN}./create-repo.sh docyazilim doc-notes private${RESET}"
+    echo -e "  ${GREEN}./create-repo.sh --dry-run docyazilim doc-notes private${RESET}"
+    echo
+}
+
+DRY_RUN=false
+
+# Help flag kontrolü
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    show_help
+    exit 0
+fi
+
+# Dry-run flag kontrolü
+if [[ "${1:-}" == "--dry-run" || "${1:-}" == "-n" ]]; then
+    DRY_RUN=true
+    shift
+fi
+
+# Parametre kontrolü
+if [ $# -ne 3 ]; then
+    echo -e "${RED}Hatalı kullanım.${RESET}"
+    echo
+    show_help
+    exit 1
+fi
+
+show_banner() {
+    echo -e "${MAGENTA}"
+    cat << 'EOF'
+██╗  ██╗ █████╗ ██████╗ ███╗   ███╗ ██████╗ ███╗   ██╗██╗ █████╗
+██║  ██║██╔══██╗██╔══██╗████╗ ████║██╔═══██╗████╗  ██║██║██╔══██╗
+███████║███████║██████╔╝██╔████╔██║██║   ██║██╔██╗ ██║██║███████║
+██╔══██║██╔══██║██╔══██╗██║╚██╔╝██║██║   ██║██║╚██╗██║██║██╔══██║
+██║  ██║██║  ██║██║  ██║██║ ╚═╝ ██║╚██████╔╝██║ ╚████║██║██║  ██║
+╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝ ╚═════╝ ╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝
+
+                 H A R M O N I A   C L I
+         Order • Balance • Structure • Discipline
+EOF
+    echo -e "${RESET}"
+}
+
+# Banner (help modunda gösterilmez)
+show_banner
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo -e "${YELLOW}[DRY-RUN] Mod aktif — yazma işlemleri atlanacak, yalnızca loglanacak.${RESET}"
+fi
+
+ACCOUNT="$1"
+REPO="$2"
+VISIBILITY="$3"
+
+LOG_FILE="create-repo-$(date +%Y%m%d-%H%M%S).log"
+
+log_info()    { echo -e "${CYAN}[INFO]${RESET}    $1" | tee -a "$LOG_FILE"; }
+log_success() { echo -e "${GREEN}[OK]${RESET}      $1" | tee -a "$LOG_FILE"; }
+log_warn()    { echo -e "${YELLOW}[WARN]${RESET}    $1" | tee -a "$LOG_FILE"; }
+log_error()   { echo -e "${RED}[ERROR]${RESET}   $1" | tee -a "$LOG_FILE"; }
+
+# Dry-run komut sarmalayıcı:
+# Dry-run modunda komutu atlar ve loglar; normal modda çalıştırır.
+dry() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY-RUN] Atlandı: $*"
+        return 0
+    fi
+    "$@"
+}
+
+ensure_main_branch() {
+    local current_branch
+    current_branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+
+    if [[ -z "$current_branch" ]]; then
+        log_error "Aktif branch belirlenemedi. Detached HEAD durumunda işlem yapılamaz."
+        exit 1
+    fi
+
+    if [[ "$current_branch" != "main" ]]; then
+        log_info "Aktif branch 'main' olarak ayarlanıyor"
+        dry git branch -M main
+        log_success "Aktif branch 'main' oldu"
+    fi
+}
+
+confirm_initial_commit() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY-RUN] Kullanıcı onayı atlandı (dry-run modunda commit yapılmaz)"
+        return 0
+    fi
+    local answer
+    echo
+    echo -e "${YELLOW}Bu işlem ilk commit'i oluşturacak ve çalışma dizinindeki dosyaları stage edecektir.${RESET}"
+    echo -ne "Devam etmek istiyor musunuz? [y/N]: "
+    read -r answer
+
+    if [[ ! "$answer" =~ ^[Yy]$ ]]; then
+        log_error "İlk commit kullanıcı tarafından iptal edildi."
+        exit 1
+    fi
+}
+
+# [FIX v1.3] guard_sensitive_paths: find tabanlı tarama .gitignore'u görmezden
+# geldiğinden false positive üretiyordu. Yeni yaklaşım:
+#   1. git ls-files --others --exclude-standard   → untracked ama .gitignore'suz dosyalar
+#   2. git diff --cached --name-only              → zaten staged olan dosyalar
+# Her iki küme de hassas pattern'e karşı kontrol ediliyor.
+# Bu sayede .gitignore'da tanımlı .env vb. dosyalar taramayı tetiklemez.
+guard_sensitive_paths() {
+    local sensitive_pattern='(^|/)(\.env(\.|$)|secrets\.|credentials\.)|(\.pem|\.key)$'
+    local blocked_untracked blocked_staged blocked_files
+
+    blocked_untracked=$(git ls-files --others --exclude-standard \
+        | grep -E "$sensitive_pattern" || true)
+
+    blocked_staged=$(git diff --cached --name-only \
+        | grep -E "$sensitive_pattern" || true)
+
+    blocked_files=$(printf '%s\n%s' "$blocked_untracked" "$blocked_staged" \
+        | grep -v '^$' | sort -u || true)
+
+    if [[ -n "$blocked_files" ]]; then
+        log_error "Hassas dosya adları tespit edildi. İlk commit durduruldu."
+        printf '%s\n' "$blocked_files" | sed 's#^#  - #' | tee -a "$LOG_FILE"
+        log_error "Bu dosyaları gözden geçirip güvenli hale getirmeden devam etmeyin."
+        exit 1
+    fi
+}
+
+# Görünürlük doğrulaması
+if [[ "$VISIBILITY" != "public" && "$VISIBILITY" != "private" ]]; then
+    log_error "Geçersiz görünürlük: '$VISIBILITY'. 'public' veya 'private' olmalı."
+    exit 1
+fi
+
+# gh auth kontrolü
+if ! command -v gh >/dev/null 2>&1; then
+    log_error "GitHub CLI bulunamadı. Önce 'gh' kurup PATH'e ekleyin."
+    exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+    log_error "GitHub CLI oturumu açık değil. Lütfen önce 'gh auth login' çalıştırın."
+    exit 1
+fi
+log_success "GitHub CLI oturumu doğrulandı"
+
+# [FIX v1.3] HAS_GIT_REPO flag'i kaldırıldı. Önceki tasarımda dry-run'da
+# HAS_GIT_REPO=false set edilip else bloğuna giriliyordu; bu blok DRY_RUN
+# kontrolü yapmadığından normal modda git repo yokken ensure_main_branch
+# atlanabilirdi. Yeni tasarım: ensure_main_branch her zaman dry() üzerinden
+# çağrılıyor; git init yoksa zaten set -e script'i durdurur.
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    log_info "Git reposu bulunamadı. Başlatılıyor..."
+    dry git init -b main
+    log_success "git init tamamlandı"
+fi
+
+# ensure_main_branch: dry() sarmalayıcısı içinde zaten no-op olur (dry-run'da
+# git branch -M atlanır); ayrı bir flag yönetimine gerek kalmaz.
+ensure_main_branch
+
+# İlk commit yoksa oluşturulur
+if ! git log --oneline -1 >/dev/null 2>&1; then
+    confirm_initial_commit
+    guard_sensitive_paths
+    log_info "Staging ve initial commit yapılıyor..."
+    dry git add .
+    dry git commit -m "chore: initial commit"
+    log_success "Initial commit atıldı"
+else
+    log_info "Mevcut commit geçmişi korunuyor"
+fi
+
+# Remote zaten tanımlıysa uyar ve dur
+if git remote get-url origin >/dev/null 2>&1; then
+    log_error "'origin' remote zaten tanımlı. Önce 'git remote remove origin' çalıştırın."
+    exit 1
+fi
+
+# [FIX v1.3] gh repo create çıktısı doğrudan tee'ye pipe edildiğinde
+# set -euo pipefail altında gh hata verse bile tee başarılı döndüğünden
+# hata sessizce yutuluyordu. Yeni yaklaşım: stdout+stderr önce log dosyasına
+# tee ile yazılır, ardından PIPESTATUS[0] ile gh'nin exit code'u kontrol edilir.
+log_info "Repo oluşturuluyor: $ACCOUNT/$REPO ($VISIBILITY)"
+if [[ "$DRY_RUN" == "true" ]]; then
+    log_info "[DRY-RUN] Atlandı: gh repo create $ACCOUNT/$REPO --$VISIBILITY --source=. --push"
+else
+    gh repo create "$ACCOUNT/$REPO" \
+        --"$VISIBILITY" \
+        --source=. \
+        --push \
+        2>&1 | tee -a "$LOG_FILE"
+    # pipefail yeterli değil; gh exit code'unu PIPESTATUS üzerinden doğrula
+    if [[ "${PIPESTATUS[0]}" -ne 0 ]]; then
+        log_error "gh repo create başarısız oldu. Log dosyasını inceleyin: $LOG_FILE"
+        exit 1
+    fi
+fi
+log_success "Repo oluşturuldu ve main push edildi"
+
+# [FIX v1.3] develop branch işlemleri tamamlandıktan sonra main'e geri dönülüyor.
+# Önceki tasarımda script develop üzerinde kalıyordu; sonraki adımlarda yanlış
+# branch bağlamında işlem yapma riski vardı.
+if git show-ref --verify --quiet refs/heads/develop; then
+    log_warn "develop branch zaten var, push ediliyor"
+    dry git checkout develop
+else
+    log_info "develop branch oluşturuluyor"
+    dry git checkout -b develop
+fi
+dry git push -u origin develop
+log_success "develop branch push edildi"
+
+# develop işi bitti; deterministik branch bağlamı için main'e dön
+dry git checkout main
+log_info "main branch'e geri dönüldü"
+
+log_info "develop default branch olarak ayarlanıyor"
+if [[ "$DRY_RUN" == "true" ]]; then
+    log_info "[DRY-RUN] Atlandı: gh api PATCH repos/$ACCOUNT/$REPO -f default_branch=develop"
+else
+    gh api \
+      -X PATCH \
+      "repos/$ACCOUNT/$REPO" \
+      -f default_branch=develop \
+      2>&1 | tee -a "$LOG_FILE"
+    if [[ "${PIPESTATUS[0]}" -ne 0 ]]; then
+        log_error "default_branch ayarlanamadı. Log dosyasını inceleyin: $LOG_FILE"
+        exit 1
+    fi
+fi
+log_success "develop default branch oldu"
+
+apply_branch_protection() {
+    local BRANCH="$1"
+    local payload
+    log_info "$BRANCH branch protection ayarlanıyor"
+    payload=$(cat <<EOF
+{
+    "required_status_checks": null,
+    "enforce_admins": true,
+    "required_pull_request_reviews": {
+        "required_approving_review_count": 0
+    },
+    "restrictions": null,
+    "allow_force_pushes": false,
+    "allow_deletions": false,
+    "block_creations": false,
+    "required_conversation_resolution": false,
+    "lock_branch": false,
+    "allow_fork_syncing": false
+}
+EOF
+)
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY-RUN] Atlandı: gh api PUT repos/$ACCOUNT/$REPO/branches/$BRANCH/protection"
+    else
+        gh api \
+          -X PUT \
+          "repos/$ACCOUNT/$REPO/branches/$BRANCH/protection" \
+          --input - \
+          <<< "$payload" \
+          2>&1 | tee -a "$LOG_FILE"
+        if [[ "${PIPESTATUS[0]}" -ne 0 ]]; then
+            log_error "$BRANCH branch protection ayarlanamadı. Log: $LOG_FILE"
+            exit 1
+        fi
+    fi
+    log_success "$BRANCH branch koruması uygulandı"
+}
+
+apply_branch_protection "main"
+apply_branch_protection "develop"
+
+log_info "Merge yöntemi squash-only olarak ayarlanıyor"
+if [[ "$DRY_RUN" == "true" ]]; then
+    log_info "[DRY-RUN] Atlandı: gh api PATCH repos/$ACCOUNT/$REPO squash-only merge"
+else
+    gh api \
+      -X PATCH \
+      "repos/$ACCOUNT/$REPO" \
+      -f allow_squash_merge=true \
+      -f allow_merge_commit=false \
+      -f allow_rebase_merge=false \
+      2>&1 | tee -a "$LOG_FILE"
+    if [[ "${PIPESTATUS[0]}" -ne 0 ]]; then
+        log_error "Merge yöntemi ayarlanamadı. Log: $LOG_FILE"
+        exit 1
+    fi
+fi
+log_success "Merge yöntemi squash-only"
+
+log_info "Copilot Auto Review aktif ediliyor"
+if [[ "$DRY_RUN" == "true" ]]; then
+    log_info "[DRY-RUN] Atlandı: gh api PUT repos/$ACCOUNT/$REPO/code-review-assistants/copilot"
+else
+    response=$(gh api \
+      -X PUT \
+      "repos/$ACCOUNT/$REPO/code-review-assistants/copilot" \
+      -f enabled=true \
+      2>&1)
+    status=$?
+    printf '%s\n' "$response" | tee -a "$LOG_FILE"
+
+    if [[ "$status" -ne 0 ]]; then
+        if echo "$response" | grep -q '"status": "404"'; then
+            log_warn "Copilot Auto Review bu organizasyonda veya repo planında desteklenmiyor (404)"
+        else
+            log_error "Copilot Auto Review aktif edilemedi. Log: $LOG_FILE"
+            exit 1
+        fi
+    else
+        log_success "Copilot Auto Review aktif"
+    fi
+fi
+
+log_success "Tüm işlemler başarıyla tamamlandı!"
+if [[ "$DRY_RUN" == "true" ]]; then
+    log_warn "DRY-RUN modu: Gerçek işlem yapılmadı. Log dosyası: $LOG_FILE"
+else
+    log_success "Repo hazır: https://github.com/$ACCOUNT/$REPO"
+fi

--- a/scripts/create-repo_v0.3.sh
+++ b/scripts/create-repo_v0.3.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# create-repo.sh
+# create-repo_v0.3.sh
 # ==============================================================================
 # HARMONIA REPO BOOTSTRAP ENGINE
 # ==============================================================================
@@ -85,7 +85,7 @@ RESET="\033[0m"
 
 show_help() {
     echo -e "${BOLD}${CYAN}Kullanım:${RESET}"
-    echo -e "  ${YELLOW}./create-repo.sh [--dry-run] <hesap> <repo-adi> <public|private>${RESET}"
+    echo -e "  ${YELLOW}./scripts/create-repo_v0.3.sh [--dry-run] <hesap> <repo-adi> <public|private>${RESET}"
     echo
 
     echo -e "${BOLD}${CYAN}Açıklama:${RESET}"
@@ -109,8 +109,8 @@ show_help() {
     echo
 
     echo -e "${BOLD}${CYAN}Ornek:${RESET}"
-    echo -e "  ${GREEN}./create-repo.sh docyazilim doc-notes private${RESET}"
-    echo -e "  ${GREEN}./create-repo.sh --dry-run docyazilim doc-notes private${RESET}"
+    echo -e "  ${GREEN}./scripts/create-repo_v0.3.sh docyazilim doc-notes private${RESET}"
+    echo -e "  ${GREEN}./scripts/create-repo_v0.3.sh --dry-run docyazilim doc-notes private${RESET}"
     echo
 }
 
@@ -213,7 +213,7 @@ confirm_initial_commit() {
     fi
 }
 
-# [FIX v1.3] guard_sensitive_paths: find tabanlı tarama .gitignore'u görmezden
+# [FIX v0.3] guard_sensitive_paths: find tabanlı tarama .gitignore'u görmezden
 # geldiğinden false positive üretiyordu. Yeni yaklaşım:
 #   1. git ls-files --others --exclude-standard   → untracked ama .gitignore'suz dosyalar
 #   2. git diff --cached --name-only              → zaten staged olan dosyalar
@@ -258,7 +258,7 @@ if ! gh auth status >/dev/null 2>&1; then
 fi
 log_success "GitHub CLI oturumu doğrulandı"
 
-# [FIX v1.3] HAS_GIT_REPO flag'i kaldırıldı. Önceki tasarımda dry-run'da
+# [FIX v0.3] HAS_GIT_REPO flag'i kaldırıldı. Önceki tasarımda dry-run'da
 # HAS_GIT_REPO=false set edilip else bloğuna giriliyordu; bu blok DRY_RUN
 # kontrolü yapmadığından normal modda git repo yokken ensure_main_branch
 # atlanabilirdi. Yeni tasarım: ensure_main_branch her zaman dry() üzerinden
@@ -291,7 +291,7 @@ if git remote get-url origin >/dev/null 2>&1; then
     exit 1
 fi
 
-# [FIX v1.3] gh repo create çıktısı doğrudan tee'ye pipe edildiğinde
+# [FIX v0.3] gh repo create çıktısı doğrudan tee'ye pipe edildiğinde
 # set -euo pipefail altında gh hata verse bile tee başarılı döndüğünden
 # hata sessizce yutuluyordu. Yeni yaklaşım: stdout+stderr önce log dosyasına
 # tee ile yazılır, ardından PIPESTATUS[0] ile gh'nin exit code'u kontrol edilir.
@@ -312,7 +312,7 @@ else
 fi
 log_success "Repo oluşturuldu ve main push edildi"
 
-# [FIX v1.3] develop branch işlemleri tamamlandıktan sonra main'e geri dönülüyor.
+# [FIX v0.3] develop branch işlemleri tamamlandıktan sonra main'e geri dönülüyor.
 # Önceki tasarımda script develop üzerinde kalıyordu; sonraki adımlarda yanlış
 # branch bağlamında işlem yapma riski vardı.
 if git show-ref --verify --quiet refs/heads/develop; then

--- a/scripts/reply-resolve_v0.2.sh
+++ b/scripts/reply-resolve_v0.2.sh
@@ -1,0 +1,445 @@
+#!/usr/bin/env bash
+# reply-resolve_v0.2.sh
+# ==============================================================================
+# HARMONIA REPLY & RESOLVE ENGINE
+# ==============================================================================
+# Bu script, GitHub Pull Request’lerindeki Copilot yorumlarını otomatik olarak
+# yanıtlamak ve ilgili review thread’lerini resolve etmek için tasarlanmış
+# deterministik, üretim seviyesinde bir otomasyon aracıdır.
+#
+# Özellikler:
+# ------------------------------------------------------------------------------
+# • REST API (comments + reviews)
+#     - Copilot tarafından oluşturulan satır bazlı yorumlar (pulls/:number/comments)
+#     - Copilot review event’leri (pulls/:number/reviews)
+#
+# • GraphQL API (reviewThreads)
+#     - thread.id (GraphQL node ID)
+#     - isResolved durumu
+#     - thread içindeki tüm comment node’ları (id, body, path, line)
+#
+# • Comment → Thread Eşleştirme
+#     - REST comment.id (integer) → reply için kullanılır
+#     - REST comment.node_id (GraphQL node ID) → thread eşleştirme için kullanılır
+#     - GraphQL thread.comments.nodes[].id → node_id eşleşmesi yapılır
+#     - Böylece her comment doğru thread ile deterministik olarak eşleşir
+#
+# • Çok Modlu Reply Sistemi
+#     --mode all           : Tüm yorumlara aynı yanıt
+#     --mode filter-text   : Belirli metni içeren yorumlara yanıt
+#     --mode filter-regex  : Regex ile eşleşen yorumlara yanıt
+#     --mode map           : Pattern → reply JSON haritası (deterministik)
+#
+# • Map Modu Güvenlik Kuralları
+#     - Bir comment body’si birden fazla pattern ile eşleşirse script hata verir
+#     - Harmonia disiplinine uygun olarak belirsiz davranışa izin verilmez
+#
+# • Renkli Loglama ve Harmonia Banner
+#     - INFO / OK / WARN / ERROR seviyeleri
+#     - Tüm loglar PR klasörüne yazılır
+#
+# • Minimal Bağımlılık
+#     - bash
+#     - gh (GitHub CLI)
+#     - jq
+#
+# • Dosya Yapısı
+#     ai-review/<repo>/PR<numara>/
+#         ├── copilot-comments.json
+#         ├── review-threads.json
+#         ├── harmonia-reply-resolve-YYYYMMDD-HHMMSS.log
+#         └── (opsiyonel) reply-map.json / reply.txt
+#
+# Amaç:
+# ------------------------------------------------------------------------------
+# Copilot yorumlarını hızlı, güvenli, deterministik ve tekrarlanabilir şekilde
+# yanıtlamak ve ilgili review thread’lerini otomatik olarak resolve etmek.
+#
+# Harmonia İlkeleri:
+# ------------------------------------------------------------------------------
+# Order     → Belirsiz eşleşme yok, deterministik davranış
+# Balance   → REST + GraphQL hibrit mimari
+# Structure → Net dosya yapısı, modüler mod sistemi
+# Discipline→ Çoklu pattern eşleşmesinde hata, sessiz geçiş yok
+#
+# Değişiklik Geçmişi:
+# ------------------------------------------------------------------------------
+# v0.2  - [CHORE] Sürüm geçmişi normalize edildi (ilk yayın v0.1)
+#       - [CHORE] Dosya adı/sürüm eşleşmesi v0.2 olarak güncellendi
+# v0.1  - İlk yayın
+#
+# ==============================================================================
+
+set -euo pipefail
+
+if (( BASH_VERSINFO[0] < 4 )); then
+  echo "[ERROR] Bu script Bash 4+ gerektirir (assoc array kullanılıyor)."
+  echo "[ERROR] macOS varsayılan /bin/bash (3.2) yerine modern bash kullanın."
+  exit 1
+fi
+
+# ==============================================================================
+# --help (en başta)
+# ==============================================================================
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  cat << 'EOF'
+Kullanım:
+  reply-resolve_v0.2.sh <owner> <repo> <pr_number> --mode <mode> [seçenekler]
+
+Modlar:
+  --mode all            : Tüm Copilot comment'lerine aynı reply
+      --reply-file <dosya>
+
+  --mode filter-text    : Body içinde metin geçenlere reply
+      --filter <metin>
+      --reply-file <dosya>
+
+  --mode filter-regex   : Body regex ile eşleşenlere reply
+      --regex <pattern>
+      --reply-file <dosya>
+
+  --mode map            : Pattern → reply JSON haritası
+      --map-file <json>
+EOF
+  exit 0
+fi
+
+# ==============================================================================
+# Minimum arg kontrolü
+# ==============================================================================
+if [[ $# -lt 4 ]]; then
+  echo "[ERROR] Eksik parametre. --help ile kullanım bilgisine bakabilirsiniz."
+  exit 1
+fi
+
+# ==============================================================================
+# Arg parse
+# ==============================================================================
+OWNER="$1"; shift
+REPO="$1"; shift
+PR_NUMBER="$1"; shift
+
+MODE=""
+REPLY_FILE=""
+FILTER_TEXT=""
+FILTER_REGEX=""
+MAP_FILE=""
+
+require_option_value() {
+  local option_name="$1"
+  local option_value="${2:-}"
+  if [[ -z "$option_value" || "$option_value" == --* ]]; then
+    echo "[ERROR] ${option_name} icin deger gerekli."
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      require_option_value "--mode" "${2:-}"
+      MODE="$2"
+      shift 2
+      ;;
+    --reply-file)
+      require_option_value "--reply-file" "${2:-}"
+      REPLY_FILE="$2"
+      shift 2
+      ;;
+    --filter)
+      require_option_value "--filter" "${2:-}"
+      FILTER_TEXT="$2"
+      shift 2
+      ;;
+    --regex)
+      require_option_value "--regex" "${2:-}"
+      FILTER_REGEX="$2"
+      shift 2
+      ;;
+    --map-file)
+      require_option_value "--map-file" "${2:-}"
+      MAP_FILE="$2"
+      shift 2
+      ;;
+    *)
+      echo "[ERROR] Bilinmeyen argüman: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# ==============================================================================
+# Mode doğrulaması (arg parse SONRASI)
+# ==============================================================================
+if [[ -z "$MODE" ]]; then
+  echo "[ERROR] --mode zorunlu."
+  exit 1
+fi
+
+case "$MODE" in
+  all)
+    if [[ -z "${REPLY_FILE:-}" ]]; then
+      echo "[ERROR] --reply-file all modu için zorunlu."
+      exit 1
+    fi
+    ;;
+  filter-text)
+    if [[ -z "${FILTER_TEXT:-}" ]]; then
+      echo "[ERROR] --filter boş olamaz (filter-text modu)."
+      exit 1
+    fi
+    if [[ -z "${REPLY_FILE:-}" ]]; then
+      echo "[ERROR] --reply-file filter-text modu için zorunlu."
+      exit 1
+    fi
+    ;;
+  filter-regex)
+    if [[ -z "${FILTER_REGEX:-}" ]]; then
+      echo "[ERROR] --regex boş olamaz (filter-regex modu)."
+      exit 1
+    fi
+    if [[ -z "${REPLY_FILE:-}" ]]; then
+      echo "[ERROR] --reply-file filter-regex modu için zorunlu."
+      exit 1
+    fi
+    ;;
+  map)
+    if [[ -z "${MAP_FILE:-}" ]]; then
+      echo "[ERROR] --map-file map modu için zorunlu."
+      exit 1
+    fi
+    ;;
+  *)
+    echo "[ERROR] Geçersiz mode: $MODE"
+    exit 1
+    ;;
+esac
+
+# ==============================================================================
+# Temel doğrulamalar
+# ==============================================================================
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "[ERROR] pr_number sayısal olmalı."
+  exit 1
+fi
+
+if ! [[ "$OWNER" =~ ^[A-Za-z0-9-]+$ ]]; then
+  echo "[ERROR] owner değeri güvenli değil: $OWNER"
+  exit 1
+fi
+
+if ! [[ "$REPO" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "[ERROR] repo adı dosya yolu için güvenli değil: $REPO"
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "[ERROR] gh CLI gerekli."
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "[ERROR] gh auth login gerekli."
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[ERROR] jq gerekli."
+  exit 1
+fi
+
+# ==============================================================================
+# BASE_DIR + LOG_FILE (doğru sırada)
+# ==============================================================================
+BASE_DIR="ai-review/${REPO}/PR${PR_NUMBER}"
+mkdir -p "$BASE_DIR"
+
+LOG_FILE="${BASE_DIR}/harmonia-reply-resolve-$(date +%Y%m%d-%H%M%S).log"
+
+# ==============================================================================
+# Renkler & Log
+# ==============================================================================
+RED="\033[31m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+CYAN="\033[36m"
+MAGENTA="\033[35m"
+BOLD="\033[1m"
+RESET="\033[0m"
+
+log_info()    { echo -e "${CYAN}[INFO]${RESET}    $1" | tee -a "$LOG_FILE"; }
+log_success() { echo -e "${GREEN}[OK]${RESET}      $1" | tee -a "$LOG_FILE"; }
+log_warn()    { echo -e "${YELLOW}[WARN]${RESET}    $1" | tee -a "$LOG_FILE"; }
+log_error()   { echo -e "${RED}[ERROR]${RESET}   $1" | tee -a "$LOG_FILE"; }
+
+# ==============================================================================
+# Banner
+# ==============================================================================
+show_banner() {
+  echo -e "${MAGENTA}"
+  cat << 'EOF'
+██╗  ██╗ █████╗ ██████╗ ███╗   ███╗ ██████╗ ███╗   ██╗██╗ █████╗
+██║  ██║██╔══██╗██╔══██╗████╗ ████║██╔═══██╗████╗  ██║██║██╔══██╗
+███████║███████║██████╔╝██╔████╔██║██║   ██║██╔██╗ ██║██║███████║
+██╔══██║██╔══██║██╔══██╗██║╚██╔╝██║██║   ██║██║╚██╗██║██║██╔══██║
+██║  ██║██║  ██║██║  ██║██║ ╚═╝ ██║╚██████╔╝██║ ╚████║██║██║  ██║
+╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝ ╚═════╝ ╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝
+
+          H A R M O N I A   C O P I L O T   E N G I N E
+            Order • Balance • Structure • Discipline
+EOF
+  echo -e "${RESET}"
+}
+
+show_banner
+
+# ==============================================================================
+# JSON dosyaları
+# ==============================================================================
+COMMENTS_JSON="${BASE_DIR}/copilot-comments.json"
+THREADS_JSON="${BASE_DIR}/review-threads.json"
+
+if [[ ! -f "$COMMENTS_JSON" || ! -f "$THREADS_JSON" ]]; then
+  log_error "Collector çıktıları bulunamadı: $BASE_DIR"
+  exit 1
+fi
+
+COPILOT_LOGIN="${COPILOT_COMMENTS_LOGIN:-Copilot}"
+
+# ==============================================================================
+# Comment → Thread map (node_id bazlı)
+# ==============================================================================
+log_info "Comment node_id → Thread ID eşleştirme hazırlanıyor..."
+
+declare -A COMMENT_TO_THREAD
+
+THREAD_COUNT=$(jq 'length' "$THREADS_JSON")
+for ((i=0; i<THREAD_COUNT; i++)); do
+  THREAD_ID=$(jq -r ".[$i].id" "$THREADS_JSON")
+  COMMENT_COUNT=$(jq ".[$i].comments.nodes | length" "$THREADS_JSON")
+  for ((j=0; j<COMMENT_COUNT; j++)); do
+    CID_NODE=$(jq -r ".[$i].comments.nodes[$j].id" "$THREADS_JSON")
+    COMMENT_TO_THREAD["$CID_NODE"]="$THREAD_ID"
+  done
+done
+
+log_success "Eşleştirme tamamlandı."
+
+# ==============================================================================
+# Reply seçimi (deterministik)
+# ==============================================================================
+get_reply_for_comment() {
+  local comment_body="$1"
+
+  if [[ "$MODE" == "map" ]]; then
+    MATCHES=$(jq -r --arg body "$comment_body" '
+      .[] | select(.pattern as $p | $body | test($p)) | .reply
+    ' "$MAP_FILE")
+
+    COUNT=$(printf "%s" "$MATCHES" | grep -c '.' || true)
+
+    if [[ "$COUNT" -gt 1 ]]; then
+      log_error "Map modunda birden fazla pattern eşleşti!"
+      log_error "Comment body: $comment_body"
+      log_error "Eşleşen reply sayısı: $COUNT"
+      exit 1
+    fi
+
+    if [[ "$COUNT" -eq 1 ]]; then
+      echo "$MATCHES"
+      return
+    fi
+
+    echo ""
+    return
+  fi
+
+  cat "$REPLY_FILE"
+}
+
+# ==============================================================================
+# Hedef comment seti (id|node_id)
+# ==============================================================================
+log_info "Copilot comment listesi hazırlanıyor..."
+
+case "$MODE" in
+  all)
+    COMMENT_PAIRS=$(jq -r --arg login "$COPILOT_LOGIN" '
+      .[] | select(.user.login==$login) |
+      (.id|tostring) + "|" + .node_id
+    ' "$COMMENTS_JSON")
+    ;;
+  filter-text)
+    COMMENT_PAIRS=$(jq -r --arg login "$COPILOT_LOGIN" --arg f "$FILTER_TEXT" '
+      .[] | select(.user.login==$login and (.body | contains($f))) |
+      (.id|tostring) + "|" + .node_id
+    ' "$COMMENTS_JSON")
+    ;;
+  filter-regex)
+    COMMENT_PAIRS=$(jq -r --arg login "$COPILOT_LOGIN" --arg r "$FILTER_REGEX" '
+      .[] | select(.user.login==$login and (.body | test($r))) |
+      (.id|tostring) + "|" + .node_id
+    ' "$COMMENTS_JSON")
+    ;;
+  map)
+    COMMENT_PAIRS=$(jq -r --arg login "$COPILOT_LOGIN" '
+      .[] | select(.user.login==$login) |
+      (.id|tostring) + "|" + .node_id
+    ' "$COMMENTS_JSON")
+    ;;
+esac
+
+COUNT=$(echo "$COMMENT_PAIRS" | sed '/^$/d' | wc -l | tr -d ' ')
+log_info "Hedef Copilot comment sayısı: $COUNT"
+
+if [[ "$COUNT" -eq 0 ]]; then
+  log_warn "İşlenecek comment bulunamadı."
+  exit 0
+fi
+
+# ==============================================================================
+# Ana döngü: reply + resolve
+# ==============================================================================
+while IFS="|" read -r COMMENT_ID COMMENT_NODE_ID; do
+  [[ -z "$COMMENT_ID" || -z "$COMMENT_NODE_ID" ]] && continue
+
+  THREAD_ID="${COMMENT_TO_THREAD[$COMMENT_NODE_ID]:-}"
+  if [[ -z "$THREAD_ID" ]]; then
+    log_warn "Thread bulunamadı → comment_id=$COMMENT_ID node_id=$COMMENT_NODE_ID"
+    continue
+  fi
+
+  COMMENT_BODY=$(jq -r --arg id "$COMMENT_ID" '
+    .[] | select((.id|tostring)==$id) | .body
+  ' "$COMMENTS_JSON")
+
+  REPLY_TEXT=$(get_reply_for_comment "$COMMENT_BODY" || true)
+
+  if [[ -z "$REPLY_TEXT" ]]; then
+    log_warn "Reply bulunamadı (mode=$MODE) → comment_id=$COMMENT_ID"
+    continue
+  fi
+
+  log_info "Reply ekleniyor → comment_id=$COMMENT_ID thread_id=$THREAD_ID"
+
+  gh api \
+    -X POST \
+    "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments/${COMMENT_ID}/replies" \
+    -f body="$REPLY_TEXT" >/dev/null
+
+  log_success "Reply eklendi → $COMMENT_ID"
+
+  gh api graphql \
+    -f query="
+      mutation {
+        resolveReviewThread(input:{threadId:\"${THREAD_ID}\"}) {
+          thread { id isResolved }
+        }
+      }
+    " >/dev/null
+
+  log_success "Thread resolve edildi → $THREAD_ID"
+
+done <<< "$COMMENT_PAIRS"
+
+log_success "İşlem tamamlandı."

--- a/scripts/reply-resolve_v0.2.sh
+++ b/scripts/reply-resolve_v0.2.sh
@@ -316,9 +316,11 @@ declare -A COMMENT_TO_THREAD
 THREAD_COUNT=$(jq 'length' "$THREADS_JSON")
 for ((i=0; i<THREAD_COUNT; i++)); do
   THREAD_ID=$(jq -r ".[$i].id" "$THREADS_JSON")
+  THREAD_ID="${THREAD_ID//$'\r'/}"
   COMMENT_COUNT=$(jq ".[$i].comments.nodes | length" "$THREADS_JSON")
   for ((j=0; j<COMMENT_COUNT; j++)); do
     CID_NODE=$(jq -r ".[$i].comments.nodes[$j].id" "$THREADS_JSON")
+    CID_NODE="${CID_NODE//$'\r'/}"
     COMMENT_TO_THREAD["$CID_NODE"]="$THREAD_ID"
   done
 done
@@ -332,21 +334,22 @@ get_reply_for_comment() {
   local comment_body="$1"
 
   if [[ "$MODE" == "map" ]]; then
-    MATCHES=$(jq -r --arg body "$comment_body" '
-      .[] | select(.pattern as $p | $body | test($p)) | .reply
+    local count
+    count=$(jq -r --arg body "$comment_body" '
+      [.[] | select(.pattern as $p | $body | test($p))] | length
     ' "$MAP_FILE")
 
-    COUNT=$(printf "%s" "$MATCHES" | grep -c '.' || true)
-
-    if [[ "$COUNT" -gt 1 ]]; then
+    if [[ "$count" -gt 1 ]]; then
       log_error "Map modunda birden fazla pattern eşleşti!"
       log_error "Comment body: $comment_body"
-      log_error "Eşleşen reply sayısı: $COUNT"
+      log_error "Eşleşen reply sayısı: $count"
       exit 1
     fi
 
-    if [[ "$COUNT" -eq 1 ]]; then
-      echo "$MATCHES"
+    if [[ "$count" -eq 1 ]]; then
+      jq -r --arg body "$comment_body" '
+        [.[] | select(.pattern as $p | $body | test($p))][0].reply
+      ' "$MAP_FILE"
       return
     fi
 
@@ -403,6 +406,9 @@ fi
 while IFS="|" read -r COMMENT_ID COMMENT_NODE_ID; do
   [[ -z "$COMMENT_ID" || -z "$COMMENT_NODE_ID" ]] && continue
 
+  COMMENT_ID="${COMMENT_ID//$'\r'/}"
+  COMMENT_NODE_ID="${COMMENT_NODE_ID//$'\r'/}"
+
   THREAD_ID="${COMMENT_TO_THREAD[$COMMENT_NODE_ID]:-}"
   if [[ -z "$THREAD_ID" ]]; then
     log_warn "Thread bulunamadı → comment_id=$COMMENT_ID node_id=$COMMENT_NODE_ID"
@@ -428,6 +434,15 @@ while IFS="|" read -r COMMENT_ID COMMENT_NODE_ID; do
     -f body="$REPLY_TEXT" >/dev/null
 
   log_success "Reply eklendi → $COMMENT_ID"
+
+  THREAD_RESOLVED=$(jq -r --arg tid "$THREAD_ID" '
+    .[] | select(.id==$tid) | .isResolved
+  ' "$THREADS_JSON")
+
+  if [[ "$THREAD_RESOLVED" == "true" ]]; then
+    log_info "Thread zaten resolved, resolve adımı atlandı → $THREAD_ID"
+    continue
+  fi
 
   gh api graphql \
     -f query="

--- a/scripts/review-collector_v0.2.sh
+++ b/scripts/review-collector_v0.2.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+# review-collector_v0.2.sh
+# ==============================================================================
+# HARMONIA REVIEW COLLECTOR ENGINE
+# ==============================================================================
+# Amaç:
+#   Bu script, belirli bir Pull Request için Copilot review verilerini tek yerde
+#   toplayarak deterministik analiz ve yanıt akışını besler.
+#
+# Neden gerekli:
+#   Review yorumları REST ve GraphQL kaynaklarına dağılmış durumda olduğu için
+#   tekil çağrılarla güvenilir takip zorlaşır. Collector, bu verileri normalize
+#   ederek sonraki otomasyon adımları için tutarlı bir temel üretir.
+#
+# Özellikler:
+#   - REST API üzerinden tüm PR review comment ve review event verilerini çekme
+#   - GraphQL üzerinden review thread + thread comment verilerini sayfalı toplama
+#   - Cursor pagination ile 100+ kayıt senaryolarını eksiksiz işleme
+#   - PR klasörüne JSON artefaktları ve Markdown özet üretimi
+#   - Copilot odaklı filtreleme için login bazlı ayrıştırma
+#
+# Değişiklik Geçmişi:
+# ------------------------------------------------------------------------------
+# v0.2  - [DOC] Script üst bilgisi HARMONIA ... ENGINE formatına geçirildi
+#       - [DOC] Amaç/Neden/Özellikler bölümleri detaylandırıldı
+#       - [CHORE] Sürüm geçmişi ve dosya adı uyumu güncellendi
+# v0.1  - İlk yayın
+# ============================================================================== 
+
+set -euo pipefail
+
+# Renkler
+RED="\033[31m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+CYAN="\033[36m"
+MAGENTA="\033[35m"
+BOLD="\033[1m"
+RESET="\033[0m"
+
+log_info()    { echo -e "${CYAN}[INFO]${RESET}    $1"; }
+log_success() { echo -e "${GREEN}[OK]${RESET}      $1"; }
+log_error()   { echo -e "${RED}[ERROR]${RESET}   $1"; }
+
+banner() {
+  echo -e "${MAGENTA}"
+  cat << 'EOF'
+██╗  ██╗ █████╗ ██████╗ ███╗   ███╗ ██████╗ ███╗   ██╗██╗ █████╗
+██║  ██║██╔══██╗██╔══██╗████╗ ████║██╔═══██╗████╗  ██║██║██╔══██╗
+███████║███████║██████╔╝██╔████╔██║██║   ██║██╔██╗ ██║██║███████║
+██╔══██║██╔══██║██╔══██╗██║╚██╔╝██║██║   ██║██║╚██╗██║██║██╔══██║
+██║  ██║██║  ██║██║  ██║██║ ╚═══╝██║╚██████╔╝██║ ╚████║██║██║  ██║
+╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝ ╚═════╝ ╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝
+
+                 H A R M O N I A   C L I
+         Order • Balance • Structure • Discipline
+EOF
+  echo -e "${RESET}"
+}
+
+# Help
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  echo -e "${BOLD}Kullanım: $0 <owner> <repo> <pr_number>${RESET}"
+  exit 0
+fi
+
+banner
+
+# Parametreler
+if [[ $# -lt 3 ]]; then
+  log_error "Eksik: <owner> <repo> <pr_number>"
+  exit 1
+fi
+
+OWNER="$1"
+REPO="$2"
+PR_NUMBER="$3"
+
+# Sayısal kontrol
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  log_error "pr_number sayısal olmalı."
+  exit 1
+fi
+
+if ! [[ "$OWNER" =~ ^[A-Za-z0-9-]+$ ]]; then
+  log_error "owner değeri güvenli değil: $OWNER"
+  exit 1
+fi
+
+if ! [[ "$REPO" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  log_error "repo adı dosya yolu için güvenli değil: $REPO"
+  exit 1
+fi
+
+# Araç kontrolleri
+for cmd in gh jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log_error "$cmd gerekli."
+    exit 1
+  fi
+done
+
+if ! gh auth status >/dev/null 2>&1; then
+  log_error "gh auth login gerekli."
+  exit 1
+fi
+
+# Output
+OUTPUT_DIR="ai-review/${REPO}/PR${PR_NUMBER}"
+mkdir -p "$OUTPUT_DIR"
+
+COMMENTS_JSON="${OUTPUT_DIR}/copilot-comments.json"
+REVIEWS_JSON="${OUTPUT_DIR}/copilot-reviews.json"
+THREADS_JSON="${OUTPUT_DIR}/review-threads.json"
+MD_FILE="${OUTPUT_DIR}/copilot-review.md"
+COPILOT_COMMENTS_LOGIN="${COPILOT_COMMENTS_LOGIN:-Copilot}"
+COPILOT_REVIEWS_LOGIN="${COPILOT_REVIEWS_LOGIN:-copilot-pull-request-reviewer[bot]}"
+
+# REST: comments + reviews
+log_info "REST API: comments + reviews alınıyor..."
+
+fetch_all_pages() {
+  local endpoint="$1"
+  local all="[]"
+  local page=1
+
+  while true; do
+    local resp
+    if ! resp=$(gh api "${endpoint}?per_page=100&page=${page}" 2>/dev/null); then
+      log_error "REST API çağrısı başarısız oldu: ${endpoint} (page=${page})"
+      exit 1
+    fi
+
+    local count
+    count=$(echo "$resp" | jq 'length')
+    all=$(echo "$all $resp" | jq -s '.[0] + .[1]')
+    [[ "$count" -lt 100 ]] && break
+    page=$((page+1))
+  done
+
+  echo "$all"
+}
+
+COMMENTS_RESPONSE=$(fetch_all_pages "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments")
+REVIEWS_RESPONSE=$(fetch_all_pages "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/reviews")
+
+echo "$COMMENTS_RESPONSE" > "$COMMENTS_JSON"
+echo "$REVIEWS_RESPONSE" > "$REVIEWS_JSON"
+
+log_success "REST API kaydedildi."
+
+# GraphQL: reviewThreads
+log_info "GraphQL: review thread'leri alınıyor..."
+
+fetch_thread_comments_pages() {
+  local thread_id="$1"
+  local cursor="$2"
+  local comments_acc
+  comments_acc='[]'
+  local has_next="true"
+
+  while [[ "$has_next" == "true" ]]; do
+    local after_clause=""
+    if [[ -n "$cursor" ]]; then
+      after_clause=", after: \"${cursor}\""
+    fi
+
+    local query
+    query=$(cat <<EOF
+query {
+  node(id: "${thread_id}") {
+    ... on PullRequestReviewThread {
+      comments(first: 100${after_clause}) {
+        nodes {
+          id
+          body
+          path
+          originalLine
+          line
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+EOF
+)
+
+    local resp
+    resp=$(gh api graphql -f query="$query" 2>/dev/null || echo '{}')
+
+    local page_nodes
+    page_nodes=$(echo "$resp" | jq '.data.node.comments.nodes // []')
+    comments_acc=$(jq -s '.[0] + .[1]' <(echo "$comments_acc") <(echo "$page_nodes"))
+
+    has_next=$(echo "$resp" | jq -r '.data.node.comments.pageInfo.hasNextPage // false')
+    cursor=$(echo "$resp" | jq -r '.data.node.comments.pageInfo.endCursor // ""')
+  done
+
+  echo "$comments_acc"
+}
+
+fetch_review_threads() {
+  local threads_acc
+  threads_acc='[]'
+  local has_next="true"
+  local cursor=""
+
+  while [[ "$has_next" == "true" ]]; do
+    local after_clause=""
+    if [[ -n "$cursor" ]]; then
+      after_clause=", after: \"${cursor}\""
+    fi
+
+    local query
+    query=$(cat <<EOF
+query {
+  repository(owner: "${OWNER}", name: "${REPO}") {
+    pullRequest(number: ${PR_NUMBER}) {
+      reviewThreads(first: 100${after_clause}) {
+        nodes {
+          id
+          isResolved
+          comments(first: 100) {
+            nodes {
+              id
+              body
+              path
+              originalLine
+              line
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+EOF
+)
+
+    local resp
+    resp=$(gh api graphql -f query="$query" 2>/dev/null || echo '{}')
+
+    local page_threads
+    page_threads=$(echo "$resp" | jq '.data.repository.pullRequest.reviewThreads.nodes // []')
+    local page_count
+    page_count=$(echo "$page_threads" | jq 'length')
+
+    if [[ "$page_count" -gt 0 ]]; then
+      local idx
+      for ((idx=0; idx<page_count; idx++)); do
+        local thread
+        thread=$(echo "$page_threads" | jq ".[$idx]")
+
+        local thread_id
+        thread_id=$(echo "$thread" | jq -r '.id')
+        local thread_comments
+        thread_comments=$(echo "$thread" | jq '.comments.nodes // []')
+        local comments_has_next
+        comments_has_next=$(echo "$thread" | jq -r '.comments.pageInfo.hasNextPage // false')
+        local comments_cursor
+        comments_cursor=$(echo "$thread" | jq -r '.comments.pageInfo.endCursor // ""')
+
+        if [[ "$comments_has_next" == "true" ]]; then
+          local more_comments
+          more_comments=$(fetch_thread_comments_pages "$thread_id" "$comments_cursor")
+          thread_comments=$(jq -s '.[0] + .[1]' <(echo "$thread_comments") <(echo "$more_comments"))
+        fi
+
+        local normalized_thread
+        normalized_thread=$(jq -n \
+          --arg id "$thread_id" \
+          --argjson resolved "$(echo "$thread" | jq '.isResolved')" \
+          --argjson comments "$thread_comments" \
+          '{id: $id, isResolved: $resolved, comments: {nodes: $comments}}')
+
+        threads_acc=$(jq -s '.[0] + [.[1]]' <(echo "$threads_acc") <(echo "$normalized_thread"))
+      done
+    fi
+
+    has_next=$(echo "$resp" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false')
+    cursor=$(echo "$resp" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // ""')
+  done
+
+  echo "$threads_acc"
+}
+
+THREADS_RESPONSE=$(fetch_review_threads)
+echo "$THREADS_RESPONSE" > "$THREADS_JSON"
+
+log_success "Thread verileri kaydedildi."
+
+# Markdown raporu
+log_info "Markdown raporu üretiliyor..."
+
+{
+  echo "# Copilot Review Summary for PR #${PR_NUMBER}"
+  echo ""
+  echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo ""
+
+  COMMENT_COUNT=$(echo "$COMMENTS_RESPONSE" | jq 'length' 2>/dev/null || echo 0)
+  REVIEW_COUNT=$(echo "$REVIEWS_RESPONSE" | jq 'length' 2>/dev/null || echo 0)
+  THREAD_COUNT=$(echo "$THREADS_RESPONSE" | jq 'length' 2>/dev/null || echo 0)
+  
+  echo "**Summary:** Threads: $THREAD_COUNT | Comments: $COMMENT_COUNT | Reviews: $REVIEW_COUNT"
+  echo ""
+
+  if [[ $REVIEW_COUNT -gt 0 ]]; then
+    echo "## Copilot Reviews"
+    echo ""
+    jq -r --arg login "$COPILOT_REVIEWS_LOGIN" '
+      .[]
+      | select(.user.login == $login)
+      | "- " + (.state // "UNKNOWN") + " at " + (.submitted_at // "N/A")
+    ' <<< "$REVIEWS_RESPONSE" 2>/dev/null || true
+    echo ""
+  fi
+
+  # Threads
+  if [[ $THREAD_COUNT -gt 0 ]]; then
+    echo "## Review Threads"
+    echo ""
+    jq -r '.[] | "- \(.id) (Resolved: \(.isResolved))"' <<< "$THREADS_RESPONSE" 2>/dev/null || true
+    echo ""
+  fi
+
+  # Comments
+  if [[ $COMMENT_COUNT -gt 0 ]]; then
+    echo "## Copilot Comments"
+    echo ""
+    jq -r --arg login "$COPILOT_COMMENTS_LOGIN" '.[] | select(.user.login == $login) | "### \(.path):\(.original_line // .line // 0)\n\n\(.body)\n"' <<< "$COMMENTS_RESPONSE" 2>/dev/null || true
+  fi
+
+} > "$MD_FILE"
+
+log_success "Markdown: $MD_FILE"
+log_success "Tamamlandı!"
+
+echo ""
+echo "📁 Klasör: $OUTPUT_DIR"
+ls -lh "$OUTPUT_DIR" | tail -n +2 | awk '{print "   " $9 " (" $5 ")"}'

--- a/scripts/review-collector_v0.2.sh
+++ b/scripts/review-collector_v0.2.sh
@@ -119,6 +119,28 @@ COPILOT_REVIEWS_LOGIN="${COPILOT_REVIEWS_LOGIN:-copilot-pull-request-reviewer[bo
 # REST: comments + reviews
 log_info "REST API: comments + reviews alınıyor..."
 
+gql_query_or_fail() {
+  local query="$1"
+  local context="$2"
+  local resp
+
+  if ! resp=$(gh api graphql -f query="$query" 2>&1); then
+    log_error "GraphQL çağrısı başarısız oldu: ${context}"
+    echo "$resp" | sed 's/^/[ERROR]   /' || true
+    exit 1
+  fi
+
+  local gql_errors
+  gql_errors=$(echo "$resp" | jq '.errors // [] | length' 2>/dev/null || echo 0)
+  if [[ "$gql_errors" -gt 0 ]]; then
+    log_error "GraphQL hata döndürdü: ${context}"
+    echo "$resp" | jq -r '.errors[]?.message' | sed 's/^/[ERROR]   /' || true
+    exit 1
+  fi
+
+  echo "$resp"
+}
+
 fetch_all_pages() {
   local endpoint="$1"
   local all="[]"
@@ -190,11 +212,11 @@ EOF
 )
 
     local resp
-    resp=$(gh api graphql -f query="$query" 2>/dev/null || echo '{}')
+    resp=$(gql_query_or_fail "$query" "thread yorumları (thread_id=${thread_id})")
 
     local page_nodes
     page_nodes=$(echo "$resp" | jq '.data.node.comments.nodes // []')
-    comments_acc=$(jq -s '.[0] + .[1]' <(echo "$comments_acc") <(echo "$page_nodes"))
+    comments_acc=$(printf "%s\n%s\n" "$comments_acc" "$page_nodes" | jq -s '.[0] + .[1]')
 
     has_next=$(echo "$resp" | jq -r '.data.node.comments.pageInfo.hasNextPage // false')
     cursor=$(echo "$resp" | jq -r '.data.node.comments.pageInfo.endCursor // ""')
@@ -250,7 +272,14 @@ EOF
 )
 
     local resp
-    resp=$(gh api graphql -f query="$query" 2>/dev/null || echo '{}')
+    resp=$(gql_query_or_fail "$query" "review thread listesi")
+
+    local pr_exists
+    pr_exists=$(echo "$resp" | jq '.data.repository.pullRequest != null')
+    if [[ "$pr_exists" != "true" ]]; then
+      log_error "Pull Request bulunamadı veya erişilemiyor (owner/repo/pr_number kontrol edin)."
+      exit 1
+    fi
 
     local page_threads
     page_threads=$(echo "$resp" | jq '.data.repository.pullRequest.reviewThreads.nodes // []')
@@ -275,7 +304,7 @@ EOF
         if [[ "$comments_has_next" == "true" ]]; then
           local more_comments
           more_comments=$(fetch_thread_comments_pages "$thread_id" "$comments_cursor")
-          thread_comments=$(jq -s '.[0] + .[1]' <(echo "$thread_comments") <(echo "$more_comments"))
+          thread_comments=$(printf "%s\n%s\n" "$thread_comments" "$more_comments" | jq -s '.[0] + .[1]')
         fi
 
         local normalized_thread
@@ -285,7 +314,7 @@ EOF
           --argjson comments "$thread_comments" \
           '{id: $id, isResolved: $resolved, comments: {nodes: $comments}}')
 
-        threads_acc=$(jq -s '.[0] + [.[1]]' <(echo "$threads_acc") <(echo "$normalized_thread"))
+        threads_acc=$(printf "%s\n%s\n" "$threads_acc" "$normalized_thread" | jq -s '.[0] + [.[1]]')
       done
     fi
 

--- a/scripts/verify-review-threads_v0.2.sh
+++ b/scripts/verify-review-threads_v0.2.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# verify-review-threads_v0.2.sh
+# ==============================================================================
+# HARMONIA REVIEW THREAD VERIFICATION ENGINE
+# ==============================================================================
+# Amaç:
+#   Bu script, belirli bir Pull Request için review thread durumlarını doğrular.
+#   Özellikle "tüm thread'ler resolve edildi mi?" sorusuna deterministic yanıt verir.
+#
+# Neden gerekli:
+#   reply-resolve akışı çalıştıktan sonra geriye açık thread kalıp kalmadığını
+#   manuel kontrol etmek zaman alır ve hata riski taşır.
+#   Bu script, GraphQL üzerinden tek ve güvenilir bir doğrulama adımı sağlar.
+#
+# Özellikler:
+#   - Harmonia tasarım diline uygun banner ve renkli loglar
+#   - Detaylı yardım metni
+#   - PR bazlı thread durumu doğrulama
+#   - Cursor pagination (100+ thread durumları için eksiksiz çekim)
+#   - Markdown + JSON çıktı üretimi
+#   - Açık thread varsa non-zero exit code
+#
+# Çıktı dosyaları:
+#   ai-review/<repo>/PR<numara>/
+#       ├── review-thread-verification.json
+#       ├── review-thread-verification.md
+#       └── verify-review-threads-YYYYMMDD-HHMMSS.log
+#
+# Exit code:
+#   0  -> Tüm thread'ler resolve
+#   2  -> Açık thread var
+#   1  -> Parametre/ortam/API hatası
+#
+# Değişiklik Geçmişi:
+# ------------------------------------------------------------------------------
+# v0.2  - [CHORE] Sürüm geçmişi normalize edildi (ilk yayın v0.1)
+#       - [CHORE] Dosya adı/sürüm eşleşmesi v0.2 olarak güncellendi
+# v0.1  - İlk yayın
+# ==============================================================================
+
+set -euo pipefail
+
+# ------------------------------------------------------------------------------
+# Renkler ve log yardımcıları
+# ------------------------------------------------------------------------------
+RED="\033[31m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+CYAN="\033[36m"
+MAGENTA="\033[35m"
+BOLD="\033[1m"
+RESET="\033[0m"
+
+log_info()    { echo -e "${CYAN}[INFO]${RESET}    $1" | tee -a "$LOG_FILE"; }
+log_success() { echo -e "${GREEN}[OK]${RESET}      $1" | tee -a "$LOG_FILE"; }
+log_warn()    { echo -e "${YELLOW}[WARN]${RESET}    $1" | tee -a "$LOG_FILE"; }
+log_error()   { echo -e "${RED}[ERROR]${RESET}   $1" | tee -a "$LOG_FILE"; }
+
+# ------------------------------------------------------------------------------
+# Harmonia Banner
+# ------------------------------------------------------------------------------
+show_banner() {
+  echo -e "${MAGENTA}"
+  cat << 'EOF'
+██╗  ██╗ █████╗ ██████╗ ███╗   ███╗ ██████╗ ███╗   ██╗██╗ █████╗
+██║  ██║██╔══██╗██╔══██╗████╗ ████║██╔═══██╗████╗  ██║██║██╔══██╗
+███████║███████║██████╔╝██╔████╔██║██║   ██║██╔██╗ ██║██║███████║
+██╔══██║██╔══██║██╔══██╗██║╚██╔╝██║██║   ██║██║╚██╗██║██║██╔══██║
+██║  ██║██║  ██║██║  ██║██║ ╚═╝ ██║╚██████╔╝██║ ╚████║██║██║  ██║
+╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝ ╚═════╝ ╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝
+
+    H A R M O N I A   V E R I F I C A T I O N   E N G I N E
+           Order • Balance • Structure • Discipline
+EOF
+  echo -e "${RESET}"
+}
+
+# ------------------------------------------------------------------------------
+# Yardım metni
+# ------------------------------------------------------------------------------
+show_help() {
+  cat << 'EOF'
+Kullanım:
+  verify-review-threads_v0.2.sh <owner> <repo> <pr_number> [--show-resolved]
+
+Parametreler:
+  owner           Repo sahibi (org veya user)
+  repo            Repo adı
+  pr_number       Pull Request numarası (sayısal)
+
+Opsiyonlar:
+  --show-resolved Resolve edilmiş thread ID'lerini de listele
+  --help, -h      Yardım ekranını göster
+
+Ornek:
+  bash scripts/verify-review-threads_v0.2.sh \
+    docyazilim harmonia-platform-development 4
+
+Not:
+  Script varsayılan olarak sadece açık (isResolved=false) thread ID'lerini listeler.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  show_help
+  exit 0
+fi
+
+SHOW_RESOLVED="false"
+
+if [[ $# -lt 3 ]]; then
+  echo "[ERROR] Eksik parametre. --help ile kullanım bilgisini görün."
+  exit 1
+fi
+
+OWNER="$1"
+REPO="$2"
+PR_NUMBER="$3"
+shift 3 || true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --show-resolved)
+      SHOW_RESOLVED="true"
+      shift
+      ;;
+    --help|-h)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "[ERROR] Bilinmeyen argüman: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "[ERROR] pr_number sayısal olmalı."
+  exit 1
+fi
+
+if ! [[ "$OWNER" =~ ^[A-Za-z0-9-]+$ ]]; then
+  echo "[ERROR] owner değeri güvenli değil: $OWNER"
+  exit 1
+fi
+
+if ! [[ "$REPO" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "[ERROR] repo adı dosya yolu için güvenli değil: $REPO"
+  exit 1
+fi
+
+OUTPUT_DIR="ai-review/${REPO}/PR${PR_NUMBER}"
+mkdir -p "$OUTPUT_DIR"
+
+LOG_FILE="${OUTPUT_DIR}/verify-review-threads-$(date +%Y%m%d-%H%M%S).log"
+SUMMARY_JSON="${OUTPUT_DIR}/review-thread-verification.json"
+SUMMARY_MD="${OUTPUT_DIR}/review-thread-verification.md"
+
+show_banner
+
+# ------------------------------------------------------------------------------
+# Ortam kontrolü
+# ------------------------------------------------------------------------------
+if ! command -v gh >/dev/null 2>&1; then
+  log_error "gh CLI bulunamadı. Önce GitHub CLI kurulumunu tamamlayın."
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  log_error "jq bulunamadı. Önce jq kurulumunu tamamlayın."
+  exit 1
+fi
+
+if ! gh auth status -h github.com >/dev/null 2>&1; then
+  log_error "GitHub oturumu aktif değil. Lütfen 'gh auth login' çalıştırın."
+  exit 1
+fi
+
+log_success "Ortam doğrulaması tamamlandı"
+
+# ------------------------------------------------------------------------------
+# GraphQL üzerinden tüm review thread'leri cursor pagination ile çek
+# ------------------------------------------------------------------------------
+fetch_all_review_threads() {
+  local all_threads='[]'
+  local has_next="true"
+  local cursor=""
+
+  while [[ "$has_next" == "true" ]]; do
+    local after_clause=""
+    if [[ -n "$cursor" ]]; then
+      after_clause=", after: \"${cursor}\""
+    fi
+
+    local query
+    query=$(cat <<EOF
+query {
+  repository(owner: "${OWNER}", name: "${REPO}") {
+    pullRequest(number: ${PR_NUMBER}) {
+      reviewThreads(first: 100${after_clause}) {
+        nodes {
+          id
+          isResolved
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+EOF
+)
+
+    local response
+    if ! response=$(gh api graphql -f query="$query" 2>/dev/null); then
+      log_error "GraphQL çağrısı başarısız oldu."
+      exit 1
+    fi
+
+    if [[ -z "$response" ]]; then
+      log_error "GraphQL yanıtı boş geldi."
+      exit 1
+    fi
+
+    local gql_errors
+    gql_errors=$(echo "$response" | jq '.errors // [] | length')
+    if [[ "$gql_errors" -gt 0 ]]; then
+      log_error "GraphQL hata döndürdü."
+      echo "$response" | jq -r '.errors[]?.message' | sed 's/^/[ERROR]   /' | tee -a "$LOG_FILE"
+      exit 1
+    fi
+
+    local pr_exists
+    pr_exists=$(echo "$response" | jq '.data.repository.pullRequest != null')
+    if [[ "$pr_exists" != "true" ]]; then
+      log_error "Pull Request bulunamadı veya erişilemiyor (owner/repo/pr_number kontrol edin)."
+      exit 1
+    fi
+
+    local page_threads
+    page_threads=$(echo "$response" | jq '.data.repository.pullRequest.reviewThreads.nodes // []')
+    all_threads=$(jq -s '.[0] + .[1]' <(echo "$all_threads") <(echo "$page_threads"))
+
+    has_next=$(echo "$response" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false')
+    cursor=$(echo "$response" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // ""')
+  done
+
+  echo "$all_threads"
+}
+
+log_info "PR #${PR_NUMBER} için review thread verileri çekiliyor..."
+THREADS_JSON=$(fetch_all_review_threads)
+
+TOTAL_COUNT=$(echo "$THREADS_JSON" | jq 'length')
+RESOLVED_COUNT=$(echo "$THREADS_JSON" | jq '[.[] | select(.isResolved==true)] | length')
+UNRESOLVED_COUNT=$(echo "$THREADS_JSON" | jq '[.[] | select(.isResolved==false)] | length')
+
+UNRESOLVED_IDS=$(echo "$THREADS_JSON" | jq -r '.[] | select(.isResolved==false) | .id')
+RESOLVED_IDS=$(echo "$THREADS_JSON" | jq -r '.[] | select(.isResolved==true) | .id')
+
+# ------------------------------------------------------------------------------
+# Makine okunabilir JSON özet
+# ------------------------------------------------------------------------------
+jq -n \
+  --arg owner "$OWNER" \
+  --arg repo "$REPO" \
+  --arg pr "$PR_NUMBER" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --argjson total "$TOTAL_COUNT" \
+  --argjson resolved "$RESOLVED_COUNT" \
+  --argjson unresolved "$UNRESOLVED_COUNT" \
+  --argjson threads "$THREADS_JSON" \
+  '{
+    generatedAt: $ts,
+    owner: $owner,
+    repo: $repo,
+    prNumber: ($pr | tonumber),
+    summary: {
+      totalThreads: $total,
+      resolvedThreads: $resolved,
+      unresolvedThreads: $unresolved
+    },
+    threads: $threads
+  }' > "$SUMMARY_JSON"
+
+# ------------------------------------------------------------------------------
+# İnsan okunabilir Markdown özet
+# ------------------------------------------------------------------------------
+{
+  echo "# Review Thread Verification - PR #${PR_NUMBER}"
+  echo ""
+  echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo ""
+  echo "## Summary"
+  echo ""
+  echo "- Total: ${TOTAL_COUNT}"
+  echo "- Resolved: ${RESOLVED_COUNT}"
+  echo "- Unresolved: ${UNRESOLVED_COUNT}"
+  echo ""
+
+  echo "## Unresolved Thread IDs"
+  echo ""
+  if [[ "$UNRESOLVED_COUNT" -eq 0 ]]; then
+    echo "- None"
+  else
+    while IFS= read -r tid; do
+      [[ -z "$tid" ]] && continue
+      echo "- ${tid}"
+    done <<< "$UNRESOLVED_IDS"
+  fi
+
+  if [[ "$SHOW_RESOLVED" == "true" ]]; then
+    echo ""
+    echo "## Resolved Thread IDs"
+    echo ""
+    if [[ "$RESOLVED_COUNT" -eq 0 ]]; then
+      echo "- None"
+    else
+      while IFS= read -r tid; do
+        [[ -z "$tid" ]] && continue
+        echo "- ${tid}"
+      done <<< "$RESOLVED_IDS"
+    fi
+  fi
+} > "$SUMMARY_MD"
+
+log_success "JSON özet oluşturuldu: $SUMMARY_JSON"
+log_success "Markdown özet oluşturuldu: $SUMMARY_MD"
+
+log_info "Toplam thread: $TOTAL_COUNT"
+log_info "Resolved: $RESOLVED_COUNT"
+log_info "Unresolved: $UNRESOLVED_COUNT"
+
+if [[ "$UNRESOLVED_COUNT" -gt 0 ]]; then
+  log_warn "Açık thread bulundu. ID listesi rapora yazıldı."
+  exit 2
+fi
+
+log_success "Tüm review thread'leri resolve edilmiş durumda."
+exit 0

--- a/scripts/verify-review-threads_v0.2.sh
+++ b/scripts/verify-review-threads_v0.2.sh
@@ -242,7 +242,7 @@ EOF
 
     local page_threads
     page_threads=$(echo "$response" | jq '.data.repository.pullRequest.reviewThreads.nodes // []')
-    all_threads=$(jq -s '.[0] + .[1]' <(echo "$all_threads") <(echo "$page_threads"))
+    all_threads=$(printf "%s\n%s\n" "$all_threads" "$page_threads" | jq -s '.[0] + .[1]')
 
     has_next=$(echo "$response" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false')
     cursor=$(echo "$response" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // ""')


### PR DESCRIPTION
## Ozet
Bu PR ile workspace operasyon scriptleri `development/scripts` altindan alinip repo kokundeki `scripts/` klasorune tasindi.

## Yapilan Degisiklikler
- `scripts/` klasoru kok seviyeye tasindi.
- Script adlandirma/versiyonlama standardi korundu:
  - `review-collector_v0.2.sh`
  - `reply-resolve_v0.2.sh`
  - `verify-review-threads_v0.2.sh`
  - `cleanup_v0.2.sh`
  - `create-repo_v0.3.sh`
- Merkezi kullanim dokumani eklendi/guncellendi: `scripts/README.md`.
- Script icindeki yol/referanslar yeni konuma uyarlandi (`scripts/...`).
- Artefact cikti yollari root seviyedeki `ai-review/` yapisina guncellendi.
- Operasyon talimatlarindaki script cagri ornekleri yeni konuma cekildi.

## Neden
Workspace operasyon scriptlerinin artik bir gelistirme ara adimi degil, birinci sinif operasyon katmani olmasi hedeflendi. Bu nedenle scriptlerin kok seviyede konumlanmasi tercih edildi.

## Etki
- Eski `development/scripts` cagrilari gecersizdir.
- Yeni cagri sekli: `bash scripts/<script>.sh ...`

## Test Plani
- [x] `bash -n scripts/review-collector_v0.2.sh`
- [x] `bash -n scripts/reply-resolve_v0.2.sh`
- [x] `bash -n scripts/verify-review-threads_v0.2.sh`
- [x] `bash -n scripts/cleanup_v0.2.sh`
- [x] `bash -n scripts/create-repo_v0.3.sh`
- [x] Eski `development/scripts/...` referanslari temizlendi
- [x] Klasor tasima sonrasi kokte `scripts/` varligi dogrulandi

## Not
Bu PR sadece workspace seviyesindeki script tasima ve ilgili referans guncellemelerini kapsar; template altindaki `development/scripts` yollarina dokunulmamistir.
