### PR TITLE
chore(harmonia): add ai-review/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ Thumbs.db
 *.log
 *.tmp
 
+# Review artefacts (script çıktıları — local only)
+/ai-review/
+
 # AI agent local configs (private — root level only)
 /.claude/
 /CLAUDE.md


### PR DESCRIPTION
## Özet

Review scriptlerinin ürettiği `ai-review/<repo>/PR<number>/` artefact klasörü artık `.gitignore` kapsamına alındı.

## Motivasyon

`scripts/review-collector_v0.2.sh` çalıştırıldığında workspace kökünde `ai-review/` dizini oluşturulmaktadır. Bu dizin geçici/lokal operasyon çıktıları içerdiğinden remote repoya gitmemelidir.

## Değişiklikler

- `.gitignore`'a `/ai-review/` kuralı eklendi (root-level only)

## Test Planı

- [x] `scripts/review-collector_v0.2.sh` çalıştırılır → `ai-review/` dizini oluşur
- [x] `git status` çalıştırılır → `ai-review/` untracked olarak **görünmez** (gitignore'da)
- [x] `git add .` yapılır → `ai-review/` staged olmaz
- [x] `scripts/cleanup_v0.2.sh` çalıştırılır → dizin temizlenir