### PR TITLE
chore: scripts UTF-8 encoding ve YAML duzeltmeleri

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://squidfunk.github.io/mkdocs-material/schema.json
 site_name: Harmonia
 site_description: AI ajan destekli tam otomatik hazır proje template platformu
 site_url: https://drokian.github.io/harmonia-platform/

--- a/scripts/Invoke-ReplyResolve.ps1
+++ b/scripts/Invoke-ReplyResolve.ps1
@@ -65,7 +65,7 @@ $ErrorActionPreference = 'Stop'
 [Console]::InputEncoding  = [System.Text.Encoding]::UTF8
 $OutputEncoding           = [System.Text.Encoding]::UTF8
 
-$Red
+$Red = "`e[31m"
 $Green = "`e[32m"
 $Yellow = "`e[33m"
 $Cyan = "`e[36m"

--- a/scripts/Invoke-ReplyResolve.ps1
+++ b/scripts/Invoke-ReplyResolve.ps1
@@ -11,6 +11,10 @@
     - filter-text
     - filter-regex
     - map
+.NOTES
+    Version History:
+    - v1.0.0 (2026-04-18): İlk sürüm.
+    - v1.1.0 (2026-04-30): [Console]::OutputEncoding UTF-8 zorlandı; gh CLI çağrıları System.Diagnostics.Process tabanlı Invoke-GhProcess sarmalayıcısına taşındı; IBM857 mojibake sorunu giderildi.
 .PARAMETER Owner
     GitHub owner (org/user).
 .PARAMETER Repo
@@ -52,10 +56,16 @@ param(
     [string]$MapFile = ''
 )
 
+$ScriptVersion = "v1.1.0"
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$Red = "`e[31m"
+# gh CLI UTF-8 çıktısını doğru okumak için konsol encoding'i zorla
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::InputEncoding  = [System.Text.Encoding]::UTF8
+$OutputEncoding           = [System.Text.Encoding]::UTF8
+
+$Red
 $Green = "`e[32m"
 $Yellow = "`e[33m"
 $Cyan = "`e[36m"
@@ -142,15 +152,34 @@ function Read-JsonFile([string]$Path) {
     return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -Depth 100
 }
 
+function Invoke-GhProcess {
+    param([Parameter(Mandatory)][string[]]$Arguments)
+    $ghPath = (Get-Command gh -ErrorAction Stop).Source
+    $psi = [System.Diagnostics.ProcessStartInfo]::new($ghPath)
+    foreach ($arg in $Arguments) { $psi.ArgumentList.Add($arg) }
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute        = $false
+    $psi.StandardOutputEncoding = [System.Text.Encoding]::UTF8
+    $psi.StandardErrorEncoding  = [System.Text.Encoding]::UTF8
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+    $stderrTask = $proc.StandardError.ReadToEndAsync()
+    $proc.WaitForExit()
+    $stdout = $stdoutTask.GetAwaiter().GetResult()
+    $stderr = $stderrTask.GetAwaiter().GetResult()
+    return [PSCustomObject]@{ ExitCode = $proc.ExitCode; Stdout = $stdout; Stderr = $stderr }
+}
+
 function Invoke-Gh {
     param([string[]]$Arguments, [string]$Context)
-    $result = & gh @Arguments 2>&1
-    if ($LASTEXITCODE -ne 0) {
+    $proc = Invoke-GhProcess -Arguments $Arguments
+    if ($proc.ExitCode -ne 0) {
         Log-Err "$Context basarisiz."
-        $result | ForEach-Object { Write-Host "[ERROR]   $_" }
+        $proc.Stderr.Split("`n") | ForEach-Object { Write-Host "[ERROR]   $_" }
         exit 1
     }
-    return ($result -join "`n")
+    return $proc.Stdout
 }
 
 function Get-ReplyForComment([string]$CommentBody, [string]$FallbackReplyText, [object[]]$ReplyMap) {

--- a/scripts/Invoke-ReviewCollector.ps1
+++ b/scripts/Invoke-ReviewCollector.ps1
@@ -5,7 +5,7 @@
     Collects Copilot review artifacts for a pull request.
 .DESCRIPTION
     PowerShell 7 equivalent of review-collector_v0.2.sh.
-    Produces artifacts under development/.ai-review/<owner>.<repo>/PR-<number>/:
+    Produces artifacts under ai-review/<repo>/PR<number>/:
     - copilot-comments.json
     - copilot-reviews.json
     - review-threads.json
@@ -15,7 +15,7 @@
     - v1.0.0 (2026-04-18): İlk sürüm.
     - v1.1.0 (2026-04-20): GraphQL sorguları için güvenli değişken yönetimi (-f/-F) eklendi.
     - v1.2.0 (2026-04-22): API istekleri Start-ThreadJob ile asenkron hale getirildi.
-    - v1.2.1 (2026-04-23): Hata yönetimi ve kullanıcı geri bildirimleri geliştirildi. Outputdir yapısı optimize edildi.
+    - v1.3.0 (2026-04-30): [Console]::OutputEncoding UTF-8 zorlandı; IBM857 mojibake sorunu giderildi.
 .PARAMETER Owner
     Repository owner (org/user).
 .PARAMETER Repo
@@ -38,9 +38,14 @@ param(
     [string]$PrNumber
 )
 
-$ScriptVersion = "v1.2.1"
+$ScriptVersion = "v1.3.0"
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+# gh CLI UTF-8 çıktısını doğru okumak için konsol encoding'i zorla
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::InputEncoding  = [System.Text.Encoding]::UTF8
+$OutputEncoding           = [System.Text.Encoding]::UTF8
 
 $Cyan = "`e[36m"
 $Green = "`e[32m"
@@ -89,6 +94,31 @@ function Ensure-Tools {
     }
 }
 
+function Invoke-GhProcess {
+    param(
+        [Parameter(Mandatory)][string[]]$Arguments
+    )
+    # gh CLI UTF-8 JSON üretir; ancak PowerShell 5 (Desktop) konsol encoding'i
+    # (IBM857 vb.) StandardOutput'u yanlış okur. ReadToEndAsync + geçici dosya
+    # kombinasyonu encoding sorununu tamamen devre dışı bırakır.
+    $ghPath = (Get-Command gh -ErrorAction Stop).Source
+    $psi = [System.Diagnostics.ProcessStartInfo]::new($ghPath)
+    foreach ($arg in $Arguments) { $psi.ArgumentList.Add($arg) }
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute        = $false
+    $psi.StandardOutputEncoding = [System.Text.Encoding]::UTF8
+    $psi.StandardErrorEncoding  = [System.Text.Encoding]::UTF8
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    # Deadlock'u önlemek için stdout+stderr'i eş zamanlı oku
+    $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+    $stderrTask = $proc.StandardError.ReadToEndAsync()
+    $proc.WaitForExit()
+    $stdout = $stdoutTask.GetAwaiter().GetResult()
+    $stderr = $stderrTask.GetAwaiter().GetResult()
+    return [PSCustomObject]@{ ExitCode = $proc.ExitCode; Stdout = $stdout; Stderr = $stderr }
+}
+
 function Gh-ApiJson {
     param(
         [Parameter(Mandatory)]
@@ -97,14 +127,14 @@ function Gh-ApiJson {
         [string]$Context
     )
 
-    $result = & gh @Arguments 2>&1
-    if ($LASTEXITCODE -ne 0) {
+    $proc = Invoke-GhProcess -Arguments $Arguments
+    if ($proc.ExitCode -ne 0) {
         Log-Err "$Context başarısız."
-        $result | ForEach-Object { Write-Host "[ERROR]   $_" }
+        $proc.Stderr.Split("`n") | ForEach-Object { Write-Host "[ERROR]   $_" }
         exit 1
     }
 
-    $outStr = ($result -join "`n").Trim()
+    $outStr = $proc.Stdout.Trim()
 
     try {
         return $outStr | ConvertFrom-Json -Depth 100
@@ -335,7 +365,7 @@ Show-Banner
 Ensure-Tools
 
 # Harmonia standart klasör yapısı
-$outputDir = Join-Path -Path "development/.ai-review/$Owner.$Repo" -ChildPath "PR-$PrNumber"
+$outputDir = Join-Path -Path "ai-review/$Repo" -ChildPath "PR$PrNumber"
 
 # Klasörü oluştur
 Safe-CreateDirectory -Path $outputDir

--- a/scripts/Invoke-ReviewCollector.ps1
+++ b/scripts/Invoke-ReviewCollector.ps1
@@ -98,9 +98,9 @@ function Invoke-GhProcess {
     param(
         [Parameter(Mandatory)][string[]]$Arguments
     )
-    # gh CLI UTF-8 JSON üretir; ancak PowerShell 5 (Desktop) konsol encoding'i
-    # (IBM857 vb.) StandardOutput'u yanlış okur. ReadToEndAsync + geçici dosya
-    # kombinasyonu encoding sorununu tamamen devre dışı bırakır.
+    # gh CLI çıktısını UTF-8 olarak okumak için process encoding ayarlarını açıkça belirliyoruz.
+    # Geçici dosya kullanılmaz; stdout ve stderr deadlock riskini azaltmak için
+    # eş zamanlı olarak ReadToEndAsync() ile okunur.
     $ghPath = (Get-Command gh -ErrorAction Stop).Source
     $psi = [System.Diagnostics.ProcessStartInfo]::new($ghPath)
     foreach ($arg in $Arguments) { $psi.ArgumentList.Add($arg) }

--- a/scripts/Test-ReviewThreads.ps1
+++ b/scripts/Test-ReviewThreads.ps1
@@ -22,6 +22,10 @@
     Pull Request numarasi.
 .PARAMETER ShowResolved
     Resolve edilmis thread ID'lerini de markdown ozete ekler.
+.NOTES
+    Version History:
+    - v1.0.0 (2026-04-18): İlk sürüm.
+    - v1.1.0 (2026-04-30): [Console]::OutputEncoding UTF-8 zorlandı; gh CLI çağrıları System.Diagnostics.Process tabanlı Invoke-GhProcess sarmalayıcısına taşındı; IBM857 mojibake sorunu giderildi.
 #>
 param(
     [Parameter(Mandatory)]
@@ -40,8 +44,14 @@ param(
     [switch]$ShowResolved
 )
 
+$ScriptVersion = "v1.1.0"
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+# gh CLI UTF-8 çıktısını doğru okumak için konsol encoding'i zorla
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::InputEncoding  = [System.Text.Encoding]::UTF8
+$OutputEncoding           = [System.Text.Encoding]::UTF8
 
 $Red = "`e[31m"
 $Green = "`e[32m"
@@ -105,17 +115,36 @@ function Ensure-Tools {
     }
 }
 
+function Invoke-GhProcess {
+    param([Parameter(Mandatory)][string[]]$Arguments)
+    $ghPath = (Get-Command gh -ErrorAction Stop).Source
+    $psi = [System.Diagnostics.ProcessStartInfo]::new($ghPath)
+    foreach ($arg in $Arguments) { $psi.ArgumentList.Add($arg) }
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute        = $false
+    $psi.StandardOutputEncoding = [System.Text.Encoding]::UTF8
+    $psi.StandardErrorEncoding  = [System.Text.Encoding]::UTF8
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+    $stderrTask = $proc.StandardError.ReadToEndAsync()
+    $proc.WaitForExit()
+    $stdout = $stdoutTask.GetAwaiter().GetResult()
+    $stderr = $stderrTask.GetAwaiter().GetResult()
+    return [PSCustomObject]@{ ExitCode = $proc.ExitCode; Stdout = $stdout; Stderr = $stderr }
+}
+
 function Invoke-GhApiJson {
     param([string[]]$Arguments, [string]$Context)
-    $result = & gh @Arguments 2>&1
-    if ($LASTEXITCODE -ne 0) {
+    $proc = Invoke-GhProcess -Arguments $Arguments
+    if ($proc.ExitCode -ne 0) {
         Log-Err "$Context basarisiz."
-        $result | ForEach-Object { Write-Host "[ERROR]   $_" }
+        $proc.Stderr.Split("`n") | ForEach-Object { Write-Host "[ERROR]   $_" }
         exit 1
     }
 
     try {
-        return ($result -join "`n") | ConvertFrom-Json -Depth 100
+        return $proc.Stdout | ConvertFrom-Json -Depth 100
     }
     catch {
         Log-Err "$Context JSON parse basarisiz: $($_.Exception.Message)"

--- a/templates/workspace-with-demo-v2/file-templates/workflows/ci.yml
+++ b/templates/workspace-with-demo-v2/file-templates/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
           fi
 
       - name: Run tests placeholder
-        run: echo "TODO: add project-specific test command"
+        run: 'echo "TODO: add project-specific test command"'


### PR DESCRIPTION
## Ozet

Editor uyarilarini ve gh CLI ciktisinda gorulen mojibake sorununu gideren karisik chore degisiklikleri.

## Degisiklikler

### `mkdocs.yml`
- Dosyanin basina `yaml-language-server` schema yorum satiri eklendi (Material schema). Editor IntelliSense/dogrulama icin.

### `scripts/` (PowerShell)
- `Invoke-ReviewCollector.ps1` -> v1.3.0
- `Invoke-ReplyResolve.ps1` -> v1.1.0
- `Test-ReviewThreads.ps1` guncellendi
- `[Console]::OutputEncoding` UTF-8 olarak zorlandi.
- `gh` CLI cagrilari `System.Diagnostics.Process` tabanli `Invoke-GhProcess` sarmalayicisina tasindi.
- IBM857 mojibake (Turkce karakterlerin bozulmasi) sorunu giderildi.

### `templates/workspace-with-demo-v2/file-templates/workflows/ci.yml`
- Test placeholder `run:` komutu tek tirnak icine alindi (YAML parser uyumlulugu).

## Test Plani

- [x] `mkdocs serve` calistir; build hatasiz.
- [x] VS Code'da `mkdocs.yml` ac; YAML hatasi/uyarisi olmamali.
- [x] `pwsh ./scripts/Invoke-ReviewCollector.ps1 -Owner drokian -Repo harmonia-platform -PrNumber <pr>` calistir; ciktida Turkce karakterler dogru gorunmeli.
- [x] `pwsh ./scripts/Invoke-ReplyResolve.ps1` mode=all/map ile dene; gh CLI ciktilari UTF-8 olmali.
- [x] `templates/workspace-with-demo-v2/file-templates/workflows/ci.yml` dosyasini yaml linter ile dogrula.
